### PR TITLE
Fix typo and punctuation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Start riv with
 
 ```$ riv```. 
 
-As an optional second parameter you can add a glob in quotes 
+As an optional second parameter you can add a glob in quotes.
 
 ```$ riv "**/*.png"```
 
@@ -52,7 +52,7 @@ You will need to install Rust and the SDL2 libraries to work with this project.
 Go [here](https://www.rust-lang.org/) for instructions on installing rust.
 Go [here](https://github.com/Rust-SDL2/rust-sdl2) for instructions on installing SDL2.
 
-After that you can build with:-
+After that you can build with:
 
 ```cargo build```
 
@@ -60,13 +60,13 @@ After that you can build with:-
 
 I aim for this project to be a great place for people just starting with Rust and just starting with Open Source to get involved. I'm pretty green with Rust myself, so any code review, refactorings to idiomatic style, bug fixes and feature PRs are very much appreciated. I have purposely left some features unimplemented before open sourcing with the idea that someone can pick them up as a good first contribution. So please, join in. No developer is too green for this project.
 
-Need made a pull request before? Check out this [5 minute video](https://www.youtube.com/watch?v=rgbCcBNZcdQ) which explains a simple process. Remember to make pull requests against the development branch.
+Never made a pull request before? Check out this [5 minute video](https://www.youtube.com/watch?v=rgbCcBNZcdQ) which explains a simple process. Remember to make pull requests against the development branch.
 
 Not sure what to work on? Check out our issues.
 
 ## Versioning
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/davejkane/riv/tags). 
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/davejkane/riv/tags).
 
 ## Authors
 


### PR DESCRIPTION
I noticed the typo (need -> never) while skimming the project. Figured I might as well fix it and found some errand white-space and a missing period in the process.

Thank you for making this open source. I might take a look at the actual code later and see if I can be of help.