### PR TITLE
Glob fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Generally the options are:-
 * Preview - Clunky and really only good for viewing one image at a time
 * Others that require a GUI folder browser
 
-Riv on the other hand runs from the command line, and accepts a glob in quotes. For example:-
+Riv on the other hand runs from the command line, and accepts a glob. For example:-
 
-```$ riv "**/*.jpg"```
+```$ riv **/*.jpg```
 
 ## Manual
 
@@ -17,9 +17,9 @@ Start riv with
 
 ```$ riv```. 
 
-As an optional second parameter you can add a glob in quotes.
+As an optional second parameter you can add a glob, space separated filepaths or even a single filepath.
 
-```$ riv "**/*.png"```
+```$ riv **/*.png```
 
 Without any second parameter, riv will look for all images in the current directory.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,7 @@ pub fn cli() -> Result<Args, String> {
             Arg::with_name("paths")
                 .required(true)
                 .multiple(true)
+                // TODO Change this to allow for empty. If empty, use glob (*).
                 .min_values(1)
                 .help("The directory or files to search for image files. A glob can be used here."),
         )

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,6 @@
 //! The cli module is used for setting up the command line app and parsing the arguments.
 
 use clap::{App, Arg};
-use glob::glob;
 use std::path::PathBuf;
 
 /// Args contains the arguments that have been successfully parsed by the clap cli app
@@ -12,8 +11,6 @@ pub struct Args {
     pub files: Vec<PathBuf>,
     /// dest_folder is the supplied or default folder for moving files
     pub dest_folder: PathBuf,
-    /// glob is the glob used in the image search
-    pub search: String,
 }
 
 /// cli sets up the command line app and parses the arguments, using clap.
@@ -23,10 +20,11 @@ pub fn cli() -> Result<Args, String> {
         .version("0.2.0")
         .about("The command line image viewer")
         .arg(
-            Arg::with_name("path")
+            Arg::with_name("paths")
                 .required(true)
-                .default_value("*")
-                .help("The directory or files to search for image files"),
+                .multiple(true)
+                .min_values(1)
+                .help("The directory or files to search for image files. A glob can be used here."),
         )
         .arg(
             Arg::with_name("dest-folder")
@@ -37,39 +35,27 @@ pub fn cli() -> Result<Args, String> {
                 .takes_value(true),
         )
         .get_matches();
-    let glob_value = match matches.value_of("path") {
+    let path_matches = match matches.values_of("paths") {
         Some(v) => v,
-        None => return Err("Failed to determine glob value".to_string()),
+        None => return Err("Failed to determine path value(s)".to_string()),
     };
-    let glob_matches = glob(glob_value).map_err(|e| e.to_string())?;
-    for path in glob_matches {
-        match path {
-            Ok(p) => {
-                if let Some(ext) = p.extension() {
-                    if let Some(ext_str) = ext.to_str() {
-                        let low = ext_str.to_string().to_lowercase();
-                        if low == "jpg"
-                            || low == "jpeg"
-                            || low == "png"
-                            || low == "bmp"
-                            || low == "webp"
-                        {
-                            files.push(p)
-                        }
-                    }
+    for path in path_matches {
+        let p = PathBuf::from(path);
+        if let Some(ext) = p.extension() {
+            if let Some(ext_str) = ext.to_str() {
+                let low = ext_str.to_string().to_lowercase();
+                if low == "jpg" || low == "jpeg" || low == "png" || low == "bmp" || low == "webp" {
+                    files.push(p)
                 }
             }
-            Err(e) => eprintln!("{}", e),
         }
     }
     let dest_folder = match matches.value_of("dest-folder") {
         Some(f) => PathBuf::from(f),
         None => return Err("failed to determine destintation folder".to_string()),
     };
-    let search = glob_value.to_owned();
     Ok(Args {
         files,
         dest_folder,
-        search,
     })
 }

--- a/src/infobar.rs
+++ b/src/infobar.rs
@@ -21,10 +21,6 @@ impl From<&Paths> for Text {
             },
             None => "No file selected".to_string(),
         };
-        let current_dir = match p.current_dir.to_str() {
-            Some(dir) => dir.to_string(),
-            None => "Unknown directory".to_string(),
-        };
         let index = if p.images.is_empty() {
             "No files in path".to_string()
         } else {

--- a/src/infobar.rs
+++ b/src/infobar.rs
@@ -8,8 +8,6 @@ use crate::paths::Paths;
 pub struct Text {
     /// current image is the string of the current image path
     pub current_image: String,
-    /// context is the string of the current directory + the glob from where the program was launched
-    pub context: String,
     /// index is the string represention of the index.
     pub index: String,
 }
@@ -27,8 +25,6 @@ impl From<&Paths> for Text {
             Some(dir) => dir.to_string(),
             None => "Unknown directory".to_string(),
         };
-        let glob = p.glob.clone();
-        let context = current_dir + "/" + &glob;
         let index = if p.images.is_empty() {
             "No files in path".to_string()
         } else {
@@ -36,7 +32,6 @@ impl From<&Paths> for Text {
         };
         Text {
             current_image,
-            context,
             index,
         }
     }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -10,8 +10,6 @@ pub struct Paths {
     pub dest_folder: PathBuf,
     /// current_dir is the path of the current directory where the program was launched from
     pub current_dir: PathBuf,
-    /// glob is the glob used in the path search. Default is "*".
-    pub glob: String,
     /// index is the index of the images vector of the current image to be displayed.
     pub index: usize,
 }

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -45,7 +45,6 @@ impl<'a> Program<'a> {
         let args = cli::cli()?;
         let images = args.files;
         let dest_folder = args.dest_folder;
-        let glob = args.search;
 
         let current_dir = match std::env::current_dir() {
             Ok(c) => c,
@@ -74,7 +73,6 @@ impl<'a> Program<'a> {
                 images,
                 dest_folder,
                 index: 0,
-                glob,
                 current_dir,
             },
             ui_state: ui::State {

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -183,10 +183,6 @@ fn blue() -> Color {
     Color::RGB(0, 180, 204)
 }
 
-fn dark_blue() -> Color {
-    Color::RGB(0, 140, 158)
-}
-
 fn grey() -> Color {
     Color::RGB(52, 56, 56)
 }

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -95,23 +95,9 @@ impl<'a> Program<'a> {
             .create_texture_from_surface(&index_surface)
             .map_err(|e| e.to_string())?;
         let index_dimensions = index_texture.query();
-        // Load the context texture
-        let context_surface = self
-            .screen
-            .font
-            .render(&text.context)
-            .blended(text_color())
-            .map_err(|e| e.to_string())?;
-        let context_texture = self
-            .screen
-            .texture_creator
-            .create_texture_from_surface(&context_surface)
-            .map_err(|e| e.to_string())?;
-        let context_dimensions = context_texture.query();
         // Draw the Bar
         let dims = (
             index_dimensions.height,
-            context_dimensions.width,
             index_dimensions.width,
             filename_dimensions.width,
         );
@@ -119,22 +105,10 @@ impl<'a> Program<'a> {
         // Copy the text textures
         let y = (self.screen.canvas.viewport().height() - index_dimensions.height) as i32;
         if let Err(e) = self.screen.canvas.copy(
-            &context_texture,
-            None,
-            Rect::new(
-                PADDING,
-                y,
-                context_dimensions.width,
-                context_dimensions.height,
-            ),
-        ) {
-            eprintln!("Failed to copy text to screen {}", e);
-        }
-        if let Err(e) = self.screen.canvas.copy(
             &index_texture,
             None,
             Rect::new(
-                (context_dimensions.width + PADDING as u32 * 2) as i32,
+                PADDING as i32,
                 y,
                 index_dimensions.width,
                 index_dimensions.height,
@@ -146,7 +120,7 @@ impl<'a> Program<'a> {
             &filename_texture,
             None,
             Rect::new(
-                (context_dimensions.width + index_dimensions.width + PADDING as u32 * 3) as i32,
+                (index_dimensions.width + PADDING as u32 * 2) as i32,
                 y,
                 filename_dimensions.width,
                 filename_dimensions.height,
@@ -158,7 +132,7 @@ impl<'a> Program<'a> {
         Ok(())
     }
 
-    fn render_bar(&mut self, dims: (u32, u32, u32, u32)) -> Result<(), String> {
+    fn render_bar(&mut self, dims: (u32, u32, u32)) -> Result<(), String> {
         let height = dims.0;
         let width = self.screen.canvas.viewport().width();
         let y = (self.screen.canvas.viewport().height() - height) as i32;
@@ -169,14 +143,8 @@ impl<'a> Program<'a> {
             eprintln!("Failed to draw bar {}", e);
         }
         x += w as i32;
-        w = dims.2 + PADDING as u32;
+        w = dims.2 + PADDING as u32 * 2;
         self.screen.canvas.set_draw_color(blue());
-        if let Err(e) = self.screen.canvas.fill_rect(Rect::new(x, y, w, height)) {
-            eprintln!("Failed to draw bar {}", e);
-        }
-        x += w as i32;
-        w = dims.3 + PADDING as u32;
-        self.screen.canvas.set_draw_color(dark_blue());
         if let Err(e) = self.screen.canvas.fill_rect(Rect::new(x, y, w, height)) {
             eprintln!("Failed to draw bar {}", e);
         }


### PR DESCRIPTION
This PR fixes the issue of `riv "~/*" not resolving to the home directory. So now rather than handling the glob directly, allow the shell to handle the glob and pass the paths on to riv. 