### PR TITLE
Fullscreen toggle cli and at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Set a destination folder for moving files with the `f` flag. The folder will be 
 | c                | Copy image to destination folder (default is ./keep)   |
 | Delete OR d      | Delete image from it's location                        |
 | t                | Toggle information bar                                 |
+| f OR F11         | Toggle fullscreen mode                                 |
 | h                | Toggle help box                                        |
 
 ## Getting Started

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,19 +5,6 @@
 use clap::{App, Arg};
 use std::path::PathBuf;
 
-/// Holding container for passing initial screen info
-/// determined at runtime.
-pub struct InitialScreenArgs {
-    /// window title
-    pub window_title: String,
-    /// x dimension of screen
-    pub window_width: u32,
-    /// y dimension of screen
-    pub window_height: u32,
-    /// current screen window is on
-    pub current_display: i32,
-}
-
 /// Args contains the arguments that have been successfully parsed by the clap cli app
 pub struct Args {
     /// files is the vector of image file paths that match the supplied or default glob

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,19 @@
 use clap::{App, Arg};
 use std::path::PathBuf;
 
+/// Holding container for passing initial screen info
+/// determined at runtime.
+pub struct InitialScreenArgs {
+    /// window title
+    pub window_title: String,
+    /// x dimension of screen
+    pub window_width: u32,
+    /// y dimension of screen
+    pub window_height: u32,
+    /// current screen window is on
+    pub current_display: i32,
+}
+
 /// Args contains the arguments that have been successfully parsed by the clap cli app
 pub struct Args {
     /// files is the vector of image file paths that match the supplied or default glob

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,8 @@ pub struct Args {
     pub files: Vec<PathBuf>,
     /// dest_folder is the supplied or default folder for moving files
     pub dest_folder: PathBuf,
+    /// Start in fullscreen mode
+    pub fullscreen: bool,
 }
 
 /// cli sets up the command line app and parses the arguments, using clap.
@@ -31,6 +33,13 @@ pub fn cli() -> Result<Args, String> {
                 .long("dest-folder")
                 .help("Desintation folder for moving files to")
                 .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("fullscreen")
+                .takes_value(false)
+                .long("fullscreen")
+                .short("F")
+                .help("Start app in fullscreen mode"),
         )
         .get_matches();
     match matches.values_of("paths") {
@@ -56,7 +65,13 @@ pub fn cli() -> Result<Args, String> {
         Some(f) => PathBuf::from(f),
         None => return Err("failed to determine destintation folder".to_string()),
     };
-    Ok(Args { files, dest_folder })
+
+    let fullscreen = matches.is_present("fullscreen");
+    Ok(Args {
+        files,
+        dest_folder,
+        fullscreen,
+    })
 }
 
 fn push_image_path(v: &mut Vec<PathBuf>, p: PathBuf) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), String> {
         .map_err(|e| e.to_string())?;
 
     let texture_creator = canvas.texture_creator();
-    let mut program = Program::init(&ttf_context, sdl_context, canvas, &texture_creator)?;
+    let mut program = Program::init(&ttf_context, sdl_context, canvas, &texture_creator, args)?;
     program.run()?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use riv::cli::{cli, InitialScreenArgs};
+use riv::cli::cli;
 use riv::program::Program;
 use std::convert::TryInto;
 
@@ -35,20 +35,8 @@ fn main() -> Result<(), String> {
         .map_err(|e| e.to_string())?;
 
     let texture_creator = canvas.texture_creator();
-    let init_screen_args = InitialScreenArgs {
-        window_title: INITIAL_TITLE.into(),
-        window_width: program_width,
-        window_height: program_height,
-        current_display: 0,
-    };
-    let mut program = Program::init(
-        &ttf_context,
-        sdl_context,
-        canvas,
-        &texture_creator,
-        args,
-        init_screen_args,
-    )?;
+
+    let mut program = Program::init(&ttf_context, sdl_context, canvas, &texture_creator, args)?;
     program.run()?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
-use riv::cli::{Args, cli};
+use riv::cli::{cli, InitialScreenArgs};
 use riv::program::Program;
 use std::convert::TryInto;
 
 fn main() -> Result<(), String> {
-    let args: Args = cli()?;
+    let args = cli()?;
     let ttf_context = sdl2::ttf::init().map_err(|e| e.to_string())?;
     let sdl_context = sdl2::init()?;
     let video = sdl_context.video()?;
@@ -16,21 +16,15 @@ fn main() -> Result<(), String> {
     let program_width = display_mode.w.try_into().unwrap();
     let program_height = display_mode.h.try_into().unwrap();
 
-    let mut window_builder = video
-        .window(
-            INITIAL_TITLE,
-            program_width,
-            program_height,
-        );
+    let mut window_builder = video.window(INITIAL_TITLE, program_width, program_height);
     if args.fullscreen {
-        window_builder.fullscreen()
-        .borderless();
-
+        window_builder.fullscreen().borderless();
     } else {
         window_builder.position_centered();
     }
-        // Still keep resizable windows for toggling between fullscreen at runtime
-       let window =  window_builder.resizable()
+    // Still keep resizable windows for toggling between fullscreen at runtime
+    let window = window_builder
+        .resizable()
         .build()
         .map_err(|e| e.to_string())?;
 
@@ -41,7 +35,20 @@ fn main() -> Result<(), String> {
         .map_err(|e| e.to_string())?;
 
     let texture_creator = canvas.texture_creator();
-    let mut program = Program::init(&ttf_context, sdl_context, canvas, &texture_creator, args)?;
+    let init_screen_args = InitialScreenArgs {
+        window_title: INITIAL_TITLE.into(),
+        window_width: program_width,
+        window_height: program_height,
+        current_display: 0,
+    };
+    let mut program = Program::init(
+        &ttf_context,
+        sdl_context,
+        canvas,
+        &texture_creator,
+        args,
+        init_screen_args,
+    )?;
     program.run()?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,9 @@ fn main() -> Result<(), String> {
             program_height,
         );
     if args.fullscreen {
-        window_builder.fullscreen();
+        window_builder.fullscreen()
+        .borderless();
+
     } else {
         window_builder.position_centered();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,14 @@ use riv::cli::cli;
 use riv::program::Program;
 use std::convert::TryInto;
 
+const INITIAL_TITLE: &str = "riv";
+
 fn main() -> Result<(), String> {
     let args = cli()?;
     let ttf_context = sdl2::ttf::init().map_err(|e| e.to_string())?;
     let sdl_context = sdl2::init()?;
     let video = sdl_context.video()?;
 
-    const INITIAL_TITLE: &str = "riv";
     // Use current display bounds for initial creation
     // Display program was launched on is number 0.
     let display_mode = video.current_display_mode(0).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,34 @@
+use riv::cli::{Args, cli};
 use riv::program::Program;
+use std::convert::TryInto;
 
 fn main() -> Result<(), String> {
+    let args: Args = cli()?;
     let ttf_context = sdl2::ttf::init().map_err(|e| e.to_string())?;
     let sdl_context = sdl2::init()?;
     let video = sdl_context.video()?;
-    let window = video
+
+    const INITIAL_TITLE: &str = "riv";
+    // Use current display bounds for initial creation
+    // Display program was launched on is number 0.
+    let display_mode = video.current_display_mode(0).unwrap();
+    // Don't see how width or height of a display could be negative
+    let program_width = display_mode.w.try_into().unwrap();
+    let program_height = display_mode.h.try_into().unwrap();
+
+    let mut window_builder = video
         .window(
-            "riv",
-            video.display_bounds(0).unwrap().width(),
-            video.display_bounds(0).unwrap().height(),
-        )
-        .position_centered()
-        .resizable()
+            INITIAL_TITLE,
+            program_width,
+            program_height,
+        );
+    if args.fullscreen {
+        window_builder.fullscreen();
+    } else {
+        window_builder.position_centered();
+    }
+        // Still keep resizable windows for toggling between fullscreen at runtime
+       let window =  window_builder.resizable()
         .build()
         .map_err(|e| e.to_string())?;
 

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -292,7 +292,8 @@ impl<'a> Program<'a> {
                     Action::Quit => break 'mainloop,
                     Action::ToggleFullscreen => {
                         self.toggle_fullscreen();
-                        self.screen.update_fullscreen(self.ui_state.fullscreen)?
+                        self.screen.update_fullscreen(self.ui_state.fullscreen)?;
+                        self.render_screen()?
                     }
                     Action::ReRender => self.render_screen()?,
                     Action::Next => self.increment(1)?,

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -87,6 +87,7 @@ impl<'a> Program<'a> {
                 right_shift: false,
                 render_infobar: true,
                 render_help: false,
+                fullscreen: args.fullscreen,
             },
         })
     }
@@ -268,6 +269,11 @@ impl<'a> Program<'a> {
         self.render_screen()
     }
 
+    /// Toggles fullscreen state of app
+    pub fn toggle_fullscreen(&mut self) {
+        self.ui_state.fullscreen = !self.ui_state.fullscreen;
+    }
+
     /// run is the event loop that listens for input and delegates accordingly.
     pub fn run(&mut self) -> Result<(), String> {
         self.render_screen()?;
@@ -276,6 +282,9 @@ impl<'a> Program<'a> {
             for event in self.screen.sdl_context.event_pump()?.poll_iter() {
                 match ui::event_action(&mut self.ui_state, &event) {
                     Action::Quit => break 'mainloop,
+                    Action::ToggleFullscreen => {
+                        self.toggle_fullscreen();
+                    }
                     Action::ReRender => self.render_screen()?,
                     Action::Next => self.increment(1)?,
                     Action::Prev => self.decrement(1)?,

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -37,12 +37,9 @@ impl<'a> Program<'a> {
     /// arguments, sets up the sdl context, creates the window, the canvas and the texture
     /// creator.
     pub fn init(
-        ttf_context: &'a Sdl2TtfContext,
-        sdl_context: Sdl,
-        canvas: Canvas<Window>,
-        texture_creator: &'a TextureCreator<WindowContext>,
+        ttf_context: &'a Sdl2TtfContext, sdl_context: Sdl, canvas: Canvas<Window>,
+        texture_creator: &'a TextureCreator<WindowContext>, args: cli::Args,
     ) -> Result<Program<'a>, String> {
-        let args = cli::cli()?;
         let images = args.files;
         let dest_folder = args.dest_folder;
 

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -37,8 +37,12 @@ impl<'a> Program<'a> {
     /// arguments, sets up the sdl context, creates the window, the canvas and the texture
     /// creator.
     pub fn init(
-        ttf_context: &'a Sdl2TtfContext, sdl_context: Sdl, canvas: Canvas<Window>,
-        texture_creator: &'a TextureCreator<WindowContext>, args: cli::Args,
+        ttf_context: &'a Sdl2TtfContext,
+        sdl_context: Sdl,
+        canvas: Canvas<Window>,
+        texture_creator: &'a TextureCreator<WindowContext>,
+        args: cli::Args,
+        screen_args: cli::InitialScreenArgs,
     ) -> Result<Program<'a>, String> {
         let images = args.files;
         let dest_folder = args.dest_folder;
@@ -75,6 +79,10 @@ impl<'a> Program<'a> {
                 last_index: 0,
                 last_texture: None,
                 dirty: false,
+                window_title: screen_args.window_title,
+                window_width: screen_args.window_width,
+                window_height: screen_args.window_height,
+                current_display: screen_args.current_display,
             },
             paths: Paths {
                 images,

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -42,7 +42,6 @@ impl<'a> Program<'a> {
         canvas: Canvas<Window>,
         texture_creator: &'a TextureCreator<WindowContext>,
         args: cli::Args,
-        screen_args: cli::InitialScreenArgs,
     ) -> Result<Program<'a>, String> {
         let images = args.files;
         let dest_folder = args.dest_folder;
@@ -79,10 +78,6 @@ impl<'a> Program<'a> {
                 last_index: 0,
                 last_texture: None,
                 dirty: false,
-                window_title: screen_args.window_title,
-                window_width: screen_args.window_width,
-                window_height: screen_args.window_height,
-                current_display: screen_args.current_display,
             },
             paths: Paths {
                 images,

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -292,6 +292,7 @@ impl<'a> Program<'a> {
                     Action::Quit => break 'mainloop,
                     Action::ToggleFullscreen => {
                         self.toggle_fullscreen();
+                        self.screen.update_fullscreen(self.ui_state.fullscreen)?
                     }
                     Action::ReRender => self.render_screen()?,
                     Action::Next => self.increment(1)?,

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -281,6 +281,7 @@ fn help_text() -> Vec<&'static str> {
         "| c                | Copy image to destination folder (default is ./keep)   |",
         "| Delete OR d      | Delete image from it's location                        |",
         "| t                | Toggle information bar                                 |",
+        "| f OR F11         | Toggle fullscreen mode                                 |",
         "| h                | Toggle help box                                        |",
         "+------------------+--------------------------------------------------------+",
     ]

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -4,6 +4,7 @@ use sdl2::render::{TextureCreator, WindowCanvas};
 use sdl2::ttf::Font;
 use sdl2::video::{FullscreenType, WindowContext};
 use sdl2::Sdl;
+use FullscreenType::*;
 
 /// Screen contains all SDL related data required for running the screen rendering.
 pub struct Screen<'a> {
@@ -28,7 +29,6 @@ pub struct Screen<'a> {
 impl Screen<'_> {
     /// Updates window for fullscreen state
     pub fn update_fullscreen(&mut self, fullscreen: bool) -> Result<(), String> {
-        use FullscreenType::*;
         let fullscreen_type = if fullscreen { Off } else { True };
         if self.canvas.window().fullscreen_state() == fullscreen_type {
             return Ok(());

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,9 +1,8 @@
 //! Screen contains the Screen struct which contains all SDL initialised data required
 //! for building the window and rendering to screen.
-
 use sdl2::render::{TextureCreator, WindowCanvas};
 use sdl2::ttf::Font;
-use sdl2::video::WindowContext;
+use sdl2::video::{FullscreenType, WindowContext};
 use sdl2::Sdl;
 
 /// Screen contains all SDL related data required for running the screen rendering.
@@ -24,4 +23,50 @@ pub struct Screen<'a> {
     pub last_texture: Option<sdl2::render::Texture<'a>>,
     /// dirty, if true indicates that last texture must be discarded
     pub dirty: bool,
+    /// window title
+    pub window_title: String,
+    /// x dimension of screen
+    pub window_width: u32,
+    /// y dimension of screen
+    pub window_height: u32,
+    /// current screen window is on
+    pub current_display: i32,
+}
+
+impl Screen<'_> {
+    /// Updates window for fullscreen state
+    pub fn update_fullscreen(&mut self, fullscreen: bool) -> Result<(), String> {
+        use FullscreenType::*;
+        let fullscreen_type = if fullscreen { Off } else { True };
+        if self.canvas.window().fullscreen_state() == fullscreen_type {
+            return Ok(());
+        }
+
+        if let Err(e) = self.canvas.window_mut().set_fullscreen(fullscreen_type) {
+            return Err(format!("failed to update display: {:?}", e).to_string());
+        }
+        match fullscreen_type {
+            Off => {
+                self.sdl_context
+                    .video()
+                    .unwrap()
+                    .window(&self.window_title, self.window_width, self.window_height)
+                    .position_centered()
+                    .resizable()
+                    .build()
+                    .unwrap();
+            }
+            Desktop | True => {
+                self.sdl_context
+                    .video()
+                    .unwrap()
+                    .window(&self.window_title, self.window_width, self.window_height)
+                    .borderless()
+                    .fullscreen()
+                    .build()
+                    .unwrap();
+            }
+        };
+        Ok(())
+    }
 }

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -23,14 +23,6 @@ pub struct Screen<'a> {
     pub last_texture: Option<sdl2::render::Texture<'a>>,
     /// dirty, if true indicates that last texture must be discarded
     pub dirty: bool,
-    /// window title
-    pub window_title: String,
-    /// x dimension of screen
-    pub window_width: u32,
-    /// y dimension of screen
-    pub window_height: u32,
-    /// current screen window is on
-    pub current_display: i32,
 }
 
 impl Screen<'_> {

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -47,24 +47,14 @@ impl Screen<'_> {
         }
         match fullscreen_type {
             Off => {
-                self.sdl_context
-                    .video()
-                    .unwrap()
-                    .window(&self.window_title, self.window_width, self.window_height)
-                    .position_centered()
-                    .resizable()
-                    .build()
-                    .unwrap();
+                let window = self.canvas.window_mut();
+                window.set_fullscreen(Off).unwrap();
+                window.set_bordered(true);
             }
             Desktop | True => {
-                self.sdl_context
-                    .video()
-                    .unwrap()
-                    .window(&self.window_title, self.window_width, self.window_height)
-                    .borderless()
-                    .fullscreen()
-                    .build()
-                    .unwrap();
+                let window = self.canvas.window_mut();
+                window.set_bordered(false);
+                window.set_fullscreen(True).unwrap();
             }
         };
         Ok(())

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -65,6 +65,10 @@ pub fn event_action(state: &mut State, event: &Event) -> Action {
         Event::KeyDown {
             keycode: Some(Keycode::F),
             ..
+        }
+        | Event::KeyDown {
+            keycode: Some(Keycode::F11),
+            ..
         } => Action::ToggleFullscreen,
         Event::Window {
             win_event: WindowEvent::Resized(_, _),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -78,6 +78,11 @@ pub fn event_action(state: &mut State, event: &Event) -> Action {
             win_event: WindowEvent::SizeChanged(_, _),
             ..
         }
+        // Rerender if the window was not changed by us.
+        | Event::Window {
+            win_event: WindowEvent::Exposed,
+            ..
+        }
         | Event::Window {
             win_event: WindowEvent::Maximized,
             ..

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -9,6 +9,8 @@ use sdl2::keyboard::Keycode;
 pub enum Action {
     /// Quit indicates the app should quit in response to this event
     Quit,
+    /// Toggle Fullscreen State
+    ToggleFullscreen,
     /// ReRender indicates the app should re-render in response to this event (such as a window
     /// resize)
     ReRender,
@@ -44,6 +46,8 @@ pub struct State {
     pub render_infobar: bool,
     /// render_help determines whether or not the help info should be rendered.
     pub render_help: bool,
+    /// Tracks fullscreen state of app.
+    pub fullscreen: bool,
 }
 
 /// event_action returns which action should be performed in response to this event
@@ -58,6 +62,10 @@ pub fn event_action(state: &mut State, event: &Event) -> Action {
             keycode: Some(Keycode::Q),
             ..
         } => Action::Quit,
+        Event::KeyDown {
+            keycode: Some(Keycode::F),
+            ..
+        } => Action::ToggleFullscreen,
         Event::Window {
             win_event: WindowEvent::Resized(_, _),
             ..


### PR DESCRIPTION
Fixes #39 
Sets the app as fullscreen or not by default.

Resizeable windows are kept so that if the user wants out of fullscreen mode later, they can resize the windowed app later.

`F` and `F11` are used to toggle between fullscreen mode at runtime.
