### PR TITLE
Add back keycode for period

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -109,6 +109,7 @@ pub fn event_action(state: &mut State, event: &Event) -> Action {
             W | PageUp => state.process_action(Action::SkipForward),
             B | PageDown => state.process_action(Action::SkipBack),
             Z => state.process_action(Action::ToggleFit),
+            Period => state.last_action.clone(),
             Home => state.process_action(Action::First),
             End => state.process_action(Action::Last),
             LShift => {


### PR DESCRIPTION
`.` `KeyDown` handling was removed during a branch merge in #55.

This adds it back.