### PR TITLE
Feat command mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ fs_extra = "1.1"
 natord = "1.0.9"
 shellexpand = "1.0"
 regex = "1.1.6"
+lazy_static = "1.3.0"
 
 [dependencies.sdl2]
 version = "0.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ glob = "0.3"
 fs_extra = "1.1"
 natord = "1.0.9"
 shellexpand = "1.0"
-regex = "1.1.6"
 
 [dependencies.sdl2]
 version = "0.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ clap = "2.33"
 glob = "0.3"
 fs_extra = "1.1"
 natord = "1.0.9"
+shellexpand = "1.0"
+regex = "1.1.6"
 
 [dependencies.sdl2]
 version = "0.32"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Set the maximum number of images to be displayed `m` or `--max` flag. 0 means in
 
 ```$ riv -m 0 **/*.png```
 
-### Controls
+### Normal Mode Controls
 
 
 | Key              | Action                                                 |
@@ -69,6 +69,19 @@ Set the maximum number of images to be displayed `m` or `--max` flag. 0 means in
 | h                | Toggle help box                                        |
 | z OR Left Click  | Toggle actual size vs scaled image                     |
 | . (period)       | Repeat last action                                     |
+
+### Command Mode Controls
+
+
+| Command                     | Action                                                   |
+|-----------------------------|----------------------------------------------------------|
+| ng OR newglob [glob]        | **Required argument** the new glob/directory/file        |
+| ? OR help                   | Toggle fullscreen mode                                   |
+| q OR quit                   | Quit                                                     |
+| sort (method)               | *Optional argument* the new method to sort by            |
+| df OR destfolder [path]     | **Required argument** new folder to move/copy images to  |
+| m OR max [positive integer] | **Required argument** new maximum number of files to view|
+
 
 ## Getting Started
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -124,7 +124,7 @@ pub fn cli() -> Result<Args, String> {
     })
 }
 
-fn push_image_path(v: &mut Vec<PathBuf>, p: PathBuf) {
+pub(crate) fn push_image_path(v: &mut Vec<PathBuf>, p: PathBuf) {
     if let Some(ext) = p.extension() {
         if let Some(ext_str) = ext.to_str() {
             let low = ext_str.to_string().to_lowercase();

--- a/src/infobar.rs
+++ b/src/infobar.rs
@@ -3,6 +3,7 @@
 //! Module InfoBar provides structures and functions for building and rendering an infobar
 
 use crate::paths::Paths;
+use crate::ui::Mode;
 
 /// Text contains the strings required to print the infobar.
 pub struct Text {
@@ -15,21 +16,22 @@ pub struct Text {
 }
 
 impl Text {
-    /// Updates the infobar
-    /// if cmd isn't empty the user is in command mode and therefore that should be displayed
-    /// instead of normal mode information. Normal mode information is the index and the current
-    /// image path
-    pub fn update(paths: &Paths, msg: Option<&str>) -> Self {
-        let information: String;
-        let mode: String;
-        match msg {
-            Some(msg) => {
-                // user is in command mode
-                information = msg.to_string();
-                mode = String::from("Command");
-            }
-            None => {
-                // user is in normal mode
+    /// Updates the infobar based on the current mode of the applicaiton
+    /// Normal Mode:
+    ///     mode = index of current image
+    ///     information = path to current image
+    /// Command Mode:
+    ///     mode = "Command"
+    ///     information = curerntly entered user string
+    /// Error Mode:
+    ///     mode = "Error"
+    ///     information = error message to display
+    pub fn update(current_mode: &Mode, paths: &Paths) -> Self {
+        let (mode, information) = match current_mode {
+            Mode::Command(msg) => ("Command".to_string(), format!(":{}", msg)),
+            Mode::Normal => {
+                let information: String;
+                let mode: String;
                 information = match paths.images.get(paths.index) {
                     Some(path) => match path.to_str() {
                         Some(name) => name.to_string(),
@@ -42,8 +44,11 @@ impl Text {
                 } else {
                     format!("{} of {}", paths.index + 1, paths.max_viewable)
                 };
+                (mode, information)
             }
-        }
+            Mode::Error(msg) => ("Error".to_string(), msg.to_string()),
+            _ => (String::new(), String::new()),
+        };
         Text { information, mode }
     }
 }

--- a/src/infobar.rs
+++ b/src/infobar.rs
@@ -19,27 +19,30 @@ impl Text {
     /// if cmd isn't empty the user is in command mode and therefore that should be displayed
     /// instead of normal mode information. Normal mode information is the index and the current
     /// image path
-    pub fn update(paths: &Paths, msg: &str) -> Self {
+    pub fn update(paths: &Paths, msg: Option<&str>) -> Self {
         let information: String;
         let mode: String;
-        if msg.is_empty() {
-            // user is in normal mode
-            information = match paths.images.get(paths.index) {
-                Some(path) => match path.to_str() {
-                    Some(name) => name.to_string(),
-                    None => "No file".to_string(),
-                },
-                None => "No file selected".to_string(),
-            };
-            mode = if paths.images.is_empty() {
-                "No files in path".to_string()
-            } else {
-                format!("{} of {}", paths.index + 1, paths.max_viewable)
-            };
-        } else {
-            // user is in command mode
-            information = msg.to_string();
-            mode = String::from("Command");
+        match msg {
+            Some(msg) => {
+                // user is in command mode
+                information = msg.to_string();
+                mode = String::from("Command");
+            }
+            None => {
+                // user is in normal mode
+                information = match paths.images.get(paths.index) {
+                    Some(path) => match path.to_str() {
+                        Some(name) => name.to_string(),
+                        None => "No file".to_string(),
+                    },
+                    None => "No file selected".to_string(),
+                };
+                mode = if paths.images.is_empty() {
+                    "No files in path".to_string()
+                } else {
+                    format!("{} of {}", paths.index + 1, paths.max_viewable)
+                };
+            }
         }
         Text { information, mode }
     }

--- a/src/infobar.rs
+++ b/src/infobar.rs
@@ -47,7 +47,7 @@ impl Text {
                 (mode, information)
             }
             Mode::Error(msg) => ("Error".to_string(), msg.to_string()),
-            _ => (String::new(), String::new()),
+            _ => ("Exit".to_string(), "Exiting... Goodbye".to_string()),
         };
         Text { information, mode }
     }

--- a/src/infobar.rs
+++ b/src/infobar.rs
@@ -6,29 +6,41 @@ use crate::paths::Paths;
 
 /// Text contains the strings required to print the infobar.
 pub struct Text {
-    /// current image is the string of the current image path
-    pub current_image: String,
-    /// index is the string represention of the index.
-    pub index: String,
+    /// Either displays the name of the current image or the current command the user is typing in
+    /// command mode
+    pub information: String,
+    /// In normal mode this is the string represention of the index, in command mode this is
+    /// "Command"
+    pub mode: String,
 }
 
-impl From<&Paths> for Text {
-    fn from(p: &Paths) -> Self {
-        let current_image = match p.images.get(p.index) {
-            Some(path) => match path.to_str() {
-                Some(name) => name.to_string(),
-                None => "No file".to_string(),
-            },
-            None => "No file selected".to_string(),
-        };
-        let index = if p.images.is_empty() {
-            "No files in path".to_string()
+impl Text {
+    /// Updates the infobar
+    /// if cmd isn't empty the user is in command mode and therefore that should be displayed
+    /// instead of normal mode information. Normal mode information is the index and the current
+    /// image path
+    pub fn update(paths: &Paths, msg: &str) -> Self {
+        let information: String;
+        let mode: String;
+        if msg.is_empty() {
+            // user is in normal mode
+            information = match paths.images.get(paths.index) {
+                Some(path) => match path.to_str() {
+                    Some(name) => name.to_string(),
+                    None => "No file".to_string(),
+                },
+                None => "No file selected".to_string(),
+            };
+            mode = if paths.images.is_empty() {
+                "No files in path".to_string()
+            } else {
+                format!("{} of {}", paths.index + 1, paths.max_viewable)
+            };
         } else {
-            format!("{} of {}", p.index + 1, p.max_viewable)
-        };
-        Text {
-            current_image,
-            index,
+            // user is in command mode
+            information = msg.to_string();
+            mode = String::from("Command");
         }
+        Text { information, mode }
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -9,8 +9,10 @@ pub struct Paths {
     pub images: Vec<PathBuf>,
     /// dest_folder is the path of the destination folder for moving and copying images.
     pub dest_folder: PathBuf,
+    /// dest_folder was modified from the default keep through Command mode df or destfolder
+    pub changed_dest_folder: bool,
     /// current_dir is the path of the current directory where the program was launched from
-    pub current_dir: PathBuf,
+    pub base_dir: PathBuf,
     /// index is the index of the images vector of the current image to be displayed.
     pub index: usize,
     /// Artificial user facing length of images limited by max cli argument

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -15,4 +15,6 @@ pub struct Paths {
     pub index: usize,
     /// Artificial user facing length of images limited by max cli argument
     pub max_viewable: usize,
+    /// Actual length the user said was maximum for images
+    pub actual_max_viewable: usize,
 }

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -76,7 +76,7 @@ fn convert_path_to_globable(path: &str) -> Result<String, String> {
     let mut absolute_path = String::from(expanded_path);
     // If path is a dir, add /* to glob
     if PathBuf::from(&absolute_path).is_dir() {
-        if !absolute_path.ends_with("/") {
+        if !absolute_path.ends_with('/') {
             absolute_path.push('/');
         }
         absolute_path.push('*');
@@ -146,7 +146,7 @@ impl<'a> Program<'a> {
                 let action = process_command_mode(&event);
                 match action {
                     Action::Backspace => {
-                        if input.len() < 1 {
+                        if input.is_empty() {
                             break 'command_loop;
                         }
                         input.pop();
@@ -194,11 +194,11 @@ impl<'a> Program<'a> {
                 }
                 let mut new_images: Vec<PathBuf>;
                 new_images = glob_path(&input_vec[1])?;
-                let mut target: Option<PathBuf> = None;
-                // the path to find in order to maintain that it is the current image
-                if !self.paths.images.is_empty() {
-                    target = Some(self.paths.images[self.paths.index].to_owned());
-                }
+                let target = if !self.paths.images.is_empty() {
+                    Some(self.paths.images[self.paths.index].to_owned())
+                } else {
+                    None
+                };
                 self.paths.images = new_images;
                 self.sorter.sort(&mut self.paths.images);
 

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -109,7 +109,6 @@ fn glob_path(path: &str) -> Result<Vec<PathBuf>, String> {
     Ok(new_images)
 }
 
-<<<<<<< HEAD
 /// Separate user input into the main command and its respected arguments
 fn parse_user_input(input: String) -> Result<(Commands, String), String> {
     // find where to split
@@ -126,34 +125,6 @@ fn parse_user_input(input: String) -> Result<(Commands, String), String> {
     let arguments = {
         if !input.is_empty() {
             input[command_terminating_index + 1..].to_owned()
-=======
-/// Uses regex to parse user input that's provided to command mode into arguments
-/// First argument is the command followed by its arguments
-fn parse_user_input(input: &str) -> Vec<String> {
-    let mut input_vec: Vec<String> = Vec::new();
-    // Regex pattern matches all unicode characters there must be at least 1
-    // and the '\' character may be present at the end of the string
-    // This is used to rather than split on whitespace, only get the actual arguments
-    lazy_static! {
-        static ref PATH_REGEX: Regex = match Regex::new(r"[\x21-\x7E]+(\\)?") {
-            Ok(regex) => regex,
-            Err(e) => panic!("Failed to construct Regex in parse_user_input: {}", e),
-        };
-    }
-
-    let mut escaped = false;
-
-    for regex_match in PATH_REGEX.captures_iter(&input) {
-        let value: String = regex_match[0].to_string();
-        if value.ends_with('\\') && !escaped {
-            escaped = true;
-            input_vec.push(value);
-        } else if escaped {
-            if let Some(last) = input_vec.last_mut() {
-                last.push(' ');
-                last.push_str(&value);
-            }
->>>>>>> refs/remotes/origin/feat-redefine-glob
         } else {
             String::new()
         }

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -286,6 +286,8 @@ impl<'a> Program<'a> {
     ///
     /// Error is returned only in serious cases, for instance if the application fails to render_screen
     pub fn run_command_mode(&mut self) -> Result<(), String> {
+        self.ui_state.render_infobar = true;
+        self.render_screen(false)?;
         let input = self.get_command(":")?;
         // after evaluating a command always exit to normal mode by default
         self.ui_state.mode = Mode::Normal;

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -132,7 +132,7 @@ fn parse_user_input(input: String) -> Result<(Commands, String), String> {
 }
 
 /// When provided a newglob set current_dir to the nearest directory
-fn find_new_current_dir(new_path: &str) -> Option<PathBuf> {
+fn find_new_base_dir(new_path: &str) -> Option<PathBuf> {
     let expanded_path = match full(new_path) {
         Ok(path) => path,
         Err(_e) => {
@@ -205,9 +205,9 @@ impl<'a> Program<'a> {
         };
         self.paths.images = new_images;
         // Set current directory to new one
-        let new_current_dir = find_new_current_dir(&path_to_newglob.replace("\\ ", " "));
-        match new_current_dir {
-            Some(current_dir) => self.paths.current_dir = current_dir,
+        let new_base_dir = find_new_base_dir(&path_to_newglob.replace("\\ ", " "));
+        match new_base_dir {
+            Some(base_dir) => self.paths.base_dir = base_dir,
             None => {}
         }
         self.sorter.sort(&mut self.paths.images);
@@ -335,8 +335,8 @@ impl<'a> Program<'a> {
                     return Ok(());
                 }
                 self.newglob(&arguments);
-                if self.paths.dest_folder.ends_with("keep") {
-                    self.paths.dest_folder = self.paths.current_dir.join("keep");
+                if !self.paths.changed_dest_folder {
+                    self.paths.dest_folder = self.paths.base_dir.join("keep");
                 }
             }
             Commands::Help => {
@@ -367,6 +367,7 @@ impl<'a> Program<'a> {
                         return Ok(());
                     }
                 }
+                self.paths.changed_dest_folder = true;
             }
             Commands::MaximumImages => {
                 if arguments.is_empty() {

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -1,0 +1,254 @@
+//! File that contains Command mode functionality, command mode in this case dictates anything that
+//! queries the user for input during run time
+use super::{Mode, Program};
+use crate::sort::SortOrder;
+use sdl2::event::WindowEvent;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Finds the provided path in paths returning the usize or error
+/// Returns 0 if not found
+fn find_path_in_paths(paths: &Vec<PathBuf>, current_path: &PathBuf) -> Option<usize> {
+    match paths.iter().position(|path| path == current_path) {
+        Some(i) => Some(i),
+        None => None,
+    }
+}
+
+/// Converts the provided path by user to a path that can be glob'd
+/// Changes $HOME and ~ to their expanded home path
+/// If the path is to a directory add glob to the end to catch the directories files
+fn convert_path_to_globable(path: &str) -> Result<String, String> {
+    let mut absolute_path = String::from(path);
+    // Get HOME environment variable
+    let home = match std::env::var("HOME") {
+        Ok(home) => home,
+        Err(e) => return Err(e.to_string()),
+    };
+
+    // create path_buf from path to get parents
+    let mut path_buf = PathBuf::from(path);
+
+    // ~ constant used to check if any parent is '~'
+    let tilda = Path::new("~");
+    // $HOME constant used to check if any parent is "$HOME"
+    let home_shell = Path::new("$HOME");
+    // replace all ~ and $HOME with home env variable
+    for parent in path_buf.ancestors() {
+        if parent == tilda {
+            absolute_path = absolute_path.replace("~", &home);
+        } else if parent == home_shell {
+            absolute_path = absolute_path.replace("$HOME", &home);
+        }
+    }
+
+    path_buf = PathBuf::from(&absolute_path);
+    // If path is a dir, add /* to glob
+    if path_buf.is_dir() {
+        if !absolute_path.ends_with("/") {
+            absolute_path.push('/');
+        }
+        absolute_path.push('*');
+    }
+    Ok(absolute_path)
+}
+
+/// Globs the passed path, returning an error if no images are in that path, glob::glob fails, or
+/// path is unexpected
+fn glob_path(path: &str) -> Result<Vec<PathBuf>, String> {
+    use crate::cli::push_image_path;
+
+    let mut new_images: Vec<PathBuf> = Vec::new();
+    let globable_path = convert_path_to_globable(path)?;
+    let path_matches = glob::glob(&globable_path).map_err(|e| e.to_string())?;
+    for path in path_matches {
+        match path {
+            Ok(p) => {
+                push_image_path(&mut new_images, p);
+            }
+            Err(e) => {
+                let err_msg = format!("Error: Unexpected path {}", e);
+                return Err(err_msg);
+            }
+        }
+    }
+    if new_images.is_empty() {
+        let err_msg = format!("Error: path \"{}\" had no images", path);
+        return Err(err_msg);
+    }
+    Ok(new_images)
+}
+
+impl<'a> Program<'a> {
+    /// User input is taken in and displayed on infobar, cmd is either '/' or ':'
+    /// Returning empty string signifies switching modes back to normal mode
+    // TODO: autocomplete use fn
+    fn get_command(&mut self, cmd: &str) -> Result<String, String> {
+        use sdl2::event::Event;
+        use sdl2::keyboard::Keycode;
+
+        // Don't need to keep length because the key that got us into this mode is already included
+        // in input
+        let mut input = String::new();
+        let video_subsystem = self.screen.sdl_context.video()?;
+        video_subsystem.text_input().start();
+        let mut events = self.screen.sdl_context.event_pump()?;
+        'command_loop: loop {
+            // text_input could not be stopped
+            for event in events.poll_iter() {
+                let display = format!("{}{}", cmd, input);
+                self.render_screen(Some(&display))?;
+                match event {
+                    Event::TextInput { text, .. } => {
+                        input.push_str(&text);
+                        // Occasionally when starting the cmd would carry over
+                        // this prevents it
+                        if input.starts_with(cmd) {
+                            input = input[1..].to_string();
+                        }
+                    }
+                    // Handle backspace, escape, and returns
+                    Event::KeyDown {
+                        keycode: Some(code),
+                        ..
+                    } => match code {
+                        Keycode::Backspace => {
+                            if input.len() > 0 {
+                                input.pop();
+                            } else {
+                                // if user deletes entire buffer quit command mode
+                                break 'command_loop;
+                            }
+                        }
+                        Keycode::Escape => {
+                            return Ok(String::new());
+                        }
+                        // User is done entering input
+                        Keycode::Return | Keycode::Return2 | Keycode::KpEnter => {
+                            break 'command_loop;
+                        }
+                        _ => continue,
+                    },
+                    Event::Window { win_event, .. } => match win_event {
+                        // Exposed: Rerender if the window was not changed by us.
+                        WindowEvent::Exposed
+                        | WindowEvent::Resized(..)
+                        | WindowEvent::SizeChanged(..)
+                        | WindowEvent::Maximized => self.render_screen(Some(&display))?,
+                        _ => continue,
+                    },
+                    _ => continue,
+                }
+            }
+            std::thread::sleep(Duration::from_millis(1000 / 60));
+        }
+        video_subsystem.text_input().stop();
+        Ok(input)
+    }
+
+    /// Enters command mode that gets user input and runs a set of possible commands based on user
+    /// input. After every command the user is set either into normal mode again or the app
+    /// terminates
+    ///
+    /// Commands:
+    ///     * ng/newglob                  requires only one addition parameter, the new current_dir.
+    ///                                     If the current image prior exists in the new glob move to that index
+    ///
+    ///     * h/help                      switches to normal mode and displays help info
+    ///
+    ///     * q/quit                      terminates the application
+    ///
+    ///     * r/reverse                   reverses current images, moving to index of current image prior to reverse
+    ///
+    ///     * df/destfolder               sets the new destination folder
+    ///
+    ///     * sort                        no argument: performs the selected sort on images, keeps
+    ///                                     moves to index of current image prior to reverse
+    ///                                   one argument: performs selected sort
+    pub fn run_command_mode(&mut self) -> Result<(), String> {
+        let input = self.get_command(":")?;
+        // after evaluating a command always exit to normal mode by default
+        self.mode = Mode::Normal;
+        // Empty input means switch back to normal mode
+        if input.is_empty() {
+            return Ok(());
+        }
+        let input_vec: Vec<&str> = input.split_whitespace().collect();
+
+        match input_vec[0] {
+            "ng" | "newglob" => {
+                if input_vec.len() < 2 {
+                    let err_msg =
+                        String::from("Error: command \"newglob\" or \":ng\" requires a glob");
+                    return Err(err_msg);
+                }
+                let mut new_images: Vec<PathBuf>;
+                new_images = glob_path(input_vec[1])?;
+                // the path to find in order to maintain that it is the current image
+                let target = self.paths.images[self.paths.index].to_owned();
+                self.paths.images = new_images;
+                self.sorter.sort(&mut self.paths.images);
+                match find_path_in_paths(&self.paths.images, &target) {
+                    Some(new_index) => self.paths.index = new_index,
+                    None => {
+                        self.paths.index = 0;
+                        // Force rerender
+                    }
+                }
+                //TODO: cache Args::Max_length for use here
+                self.paths.max_viewable = self.paths.images.len();
+            }
+            "h" | "help" => {
+                self.ui_state.render_help = !self.ui_state.render_help;
+            }
+            "q" | "quit" => {
+                self.mode = Mode::Exit;
+            }
+            "r" | "reverse" => {
+                self.paths.images.reverse();
+                self.paths.index = self.paths.max_viewable - self.paths.index - 1;
+            }
+            "df" | "destfolder" => {
+                if input_vec.len() < 2 {
+                    let err_msg =
+                        String::from("Error: command \":destfolder\" or \":d\" requires a path");
+                    return Err(err_msg);
+                }
+                self.paths.dest_folder = PathBuf::from(input_vec[1]);
+            }
+            "sort" => {
+                use std::str::FromStr;
+
+                // Allow both just calling "sort" and allow providing the new sort
+                if input_vec.len() >= 2 {
+                    let new_sort_order = match SortOrder::from_str(input_vec[1]) {
+                        Ok(order) => order,
+                        Err(e) => {
+                            return Err(format!(
+                                "Error: invalid value \"{}\". {}",
+                                input_vec[1], e
+                            ));
+                        }
+                    };
+                    self.sorter.set_order(new_sort_order);
+                }
+                // the path to find in order to maintain that it is the current image
+                let target = self.paths.images[self.paths.index].to_owned();
+                self.sorter.sort(&mut self.paths.images);
+                match find_path_in_paths(&self.paths.images, &target) {
+                    Some(new_index) => self.paths.index = new_index,
+                    None => {
+                        self.paths.index = 0;
+                        // Force rerender
+                    }
+                }
+            }
+            _ => {
+                let err_msg = format!("Error: \"{}\" is not a command", input_vec[0]);
+                return Err(err_msg);
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -107,7 +107,7 @@ impl<'a> Program<'a> {
                             input = input[1..].to_string();
                         }
                     }
-                    Action::ExitCommandMode => break 'command_loop,
+                    Action::SwitchNormalMode => break 'command_loop,
                     _ => continue,
                 }
             }

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -27,7 +27,7 @@ enum Commands {
     /// If the current image exists prior to changing globs exists in the new glob move to that index.
     /// If the new path has no images do nothing.
     NewGlob,
-    /// `:h` or `:help`
+    /// `:?` or `:help`
     ///
     /// Switches to normal mode and displays help info
     Help,
@@ -57,7 +57,7 @@ impl FromStr for Commands {
         match s {
             "sort" => Ok(Commands::Sort),
             "ng" | "newglob" => Ok(Commands::NewGlob),
-            "h" | "help" => Ok(Commands::Help),
+            "?" | "help" => Ok(Commands::Help),
             "q" | "quit" => Ok(Commands::Quit),
             "r" | "reverse" => Ok(Commands::Reverse),
             "df" | "destfolder" => Ok(Commands::DestFolder),

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -330,7 +330,8 @@ impl<'a> Program<'a> {
                 }
                 match full(&arguments) {
                     Ok(path) => {
-                        self.paths.dest_folder = PathBuf::from(path.to_string());
+                        self.paths.dest_folder =
+                            PathBuf::from(path.to_string().replace("\\ ", " "));
                     }
                     Err(e) => {
                         self.ui_state.mode =

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -326,7 +326,16 @@ impl<'a> Program<'a> {
                     );
                     return Ok(());
                 }
-                self.paths.dest_folder = PathBuf::from(&arguments);
+                match full(&arguments) {
+                    Ok(path) => {
+                        self.paths.dest_folder = PathBuf::from(path.to_string());
+                    }
+                    Err(e) => {
+                        self.ui_state.mode =
+                            Mode::Error(format!("\"{}\": {}", e.var_name, e.cause));
+                        return Ok(());
+                    }
+                }
             }
             Commands::MaximumImages => {
                 if arguments.is_empty() {

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -201,12 +201,13 @@ impl<'a> Program<'a> {
                 }
             }
         }
-        self.paths.max_viewable =
-            if self.paths.max_viewable > 0 && self.paths.max_viewable <= self.paths.images.len() {
-                self.paths.max_viewable
-            } else {
-                self.paths.images.len()
-            };
+        self.paths.max_viewable = if self.paths.actual_max_viewable > 0
+            && self.paths.actual_max_viewable <= self.paths.images.len()
+        {
+            self.paths.actual_max_viewable
+        } else {
+            self.paths.images.len()
+        };
     }
 
     /// Providing no additional arguments just sorts the current data with the already set sorting
@@ -243,7 +244,13 @@ impl<'a> Program<'a> {
                 .iter()
                 .position(|path| path == &target_path)
             {
-                Some(new_index) => self.paths.index = new_index,
+                Some(new_index) => {
+                    if new_index <= (self.paths.max_viewable - 1) {
+                        self.paths.index = new_index;
+                    } else {
+                        self.paths.index = 0;
+                    }
+                }
                 None => {
                     self.paths.index = 0;
                 }
@@ -253,17 +260,21 @@ impl<'a> Program<'a> {
 
     /// sets the new maximum_viewable images
     fn maximum_viewable(&mut self, max: &str) {
-        self.paths.max_viewable = match max.parse::<usize>() {
+        self.paths.actual_max_viewable = match max.parse::<usize>() {
             Ok(new_max) => new_max,
             Err(_e) => {
                 self.ui_state.mode = Mode::Error(format!("\"{}\" is not a positive integer", max));
                 return;
             }
         };
-        if self.paths.max_viewable > self.paths.images.len() || self.paths.max_viewable == 0 {
+        if self.paths.actual_max_viewable > self.paths.images.len()
+            || self.paths.actual_max_viewable == 0
+        {
             self.paths.max_viewable = self.paths.images.len();
+        } else {
+            self.paths.max_viewable = self.paths.actual_max_viewable;
         }
-        if self.paths.max_viewable < self.paths.index {
+        if self.paths.max_viewable <= self.paths.index {
             self.paths.index = self.paths.max_viewable - 1;
         }
     }

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -194,14 +194,26 @@ impl<'a> Program<'a> {
                 }
                 let mut new_images: Vec<PathBuf>;
                 new_images = glob_path(&input_vec[1])?;
+                let mut target: Option<PathBuf> = None;
                 // the path to find in order to maintain that it is the current image
-                let target = self.paths.images[self.paths.index].to_owned();
+                if !self.paths.images.is_empty() {
+                    target = Some(self.paths.images[self.paths.index].to_owned());
+                }
                 self.paths.images = new_images;
                 self.sorter.sort(&mut self.paths.images);
-                match self.paths.images.iter().position(|path| path == &target) {
-                    Some(new_index) => self.paths.index = new_index,
-                    None => {
-                        self.paths.index = 0;
+
+                if let Some(target_path) = target {
+                    // find location of current image, if it exists in self.paths.images
+                    match self
+                        .paths
+                        .images
+                        .iter()
+                        .position(|path| path == &target_path)
+                    {
+                        Some(new_index) => self.paths.index = new_index,
+                        None => {
+                            self.paths.index = 0;
+                        }
                     }
                 }
                 self.paths.max_viewable = if self.paths.max_viewable > 0

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -3,6 +3,7 @@
 use super::Program;
 use crate::sort::SortOrder;
 use crate::ui::{process_command_mode, Action, Mode};
+use lazy_static::lazy_static;
 use regex::Regex;
 use shellexpand::full;
 use std::path::PathBuf;
@@ -116,13 +117,16 @@ fn parse_user_input(input: &str) -> Vec<String> {
     // Regex pattern matches all unicode characters there must be at least 1
     // and the '\' character may be present at the end of the string
     // This is used to rather than split on whitespace, only get the actual arguments
-    let regex = match Regex::new(r"[\x21-\x7E]+(\\)?") {
-        Ok(regex) => regex,
-        Err(e) => panic!("Failed to construct Regex in parse_user_input: {}", e),
-    };
+    lazy_static! {
+        static ref PATH_REGEX: Regex = match Regex::new(r"[\x21-\x7E]+(\\)?") {
+            Ok(regex) => regex,
+            Err(e) => panic!("Failed to construct Regex in parse_user_input: {}", e),
+        };
+    }
+
     let mut escaped = false;
 
-    for regex_match in regex.captures_iter(&input) {
+    for regex_match in PATH_REGEX.captures_iter(&input) {
         let value: String = regex_match[0].to_string();
         if value.ends_with('\\') && !escaped {
             escaped = true;

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -196,8 +196,13 @@ impl<'a> Program<'a> {
                         // Force rerender
                     }
                 }
-                //TODO: cache Args::Max_length for use here
-                self.paths.max_viewable = self.paths.images.len();
+                self.paths.max_viewable = if self.paths.max_viewable > 0
+                    && self.paths.max_viewable <= self.paths.images.len()
+                {
+                    self.paths.max_viewable
+                } else {
+                    self.paths.images.len()
+                };
             }
             "h" | "help" => {
                 self.ui_state.render_help = !self.ui_state.render_help;
@@ -216,6 +221,28 @@ impl<'a> Program<'a> {
                     return Err(err_msg);
                 }
                 self.paths.dest_folder = PathBuf::from(input_vec[1]);
+            }
+            "m" | "max" => {
+                if input_vec.len() < 2 {
+                    let err_msg =
+                        String::from("Error: command \":max\" or \":m\" requires a new maximum number of files to display");
+                    return Err(err_msg);
+                }
+                self.paths.max_viewable = match input_vec[1].parse::<usize>() {
+                    Ok(new_max) => new_max,
+                    Err(_e) => {
+                        let err_msg =
+                            format!("Error: \"{}\" is not a positive integer", input_vec[1]);
+                        return Err(err_msg);
+                    }
+                };
+                if self.paths.max_viewable > self.paths.images.len() {
+                    self.paths.max_viewable = self.paths.images.len();
+                }
+                if self.paths.max_viewable < self.paths.index {
+                    self.paths.index = self.paths.max_viewable - 1;
+                    // force rerender
+                }
             }
             "sort" => {
                 use std::str::FromStr;

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -101,6 +101,7 @@ impl<'a> Program<'a> {
                 index: 0,
                 current_dir,
                 max_viewable,
+                actual_max_viewable: max_length,
             },
             ui_state: ui::State {
                 left_shift: false,

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -131,7 +131,7 @@ impl<'a> Program<'a> {
         else {
             self.paths.index = self.paths.max_viewable - 1;
         }
-        self.render_screen(None)
+        self.render_screen(false, None)
     }
 
     /// Removes an image from tracked images.
@@ -158,7 +158,7 @@ impl<'a> Program<'a> {
         else {
             self.paths.index = 0;
         }
-        self.render_screen(None)
+        self.render_screen(false, None)
     }
 
     /// Skips forward by the default skip increment and renders the image
@@ -176,7 +176,7 @@ impl<'a> Program<'a> {
     /// Go to and render first image in list
     fn first(&mut self) -> Result<(), String> {
         self.paths.index = 0;
-        self.render_screen(None)
+        self.render_screen(false, None)
     }
 
     /// Go to and render last image in list
@@ -186,7 +186,7 @@ impl<'a> Program<'a> {
         } else {
             self.paths.index = self.paths.max_viewable - 1;
         }
-        self.render_screen(None)
+        self.render_screen(false, None)
     }
 
     fn construct_dest_filepath(&self, src_path: &PathBuf) -> Result<PathBuf, String> {
@@ -258,7 +258,7 @@ impl<'a> Program<'a> {
 
         // Moving the image automatically advanced to next image
         // Adjust our view to reflect this
-        self.render_screen(None)
+        self.render_screen(false, None)
     }
 
     /// Deletes image currently being viewed
@@ -293,7 +293,7 @@ impl<'a> Program<'a> {
 
         // Removing the image automatically advanced to next image
         // Adjust our view to reflect this
-        self.render_screen(None)
+        self.render_screen(false, None)
     }
 
     /// Toggles fullscreen state of app
@@ -304,15 +304,15 @@ impl<'a> Program<'a> {
     /// Central run function that starts by default in Normal mode
     /// Switches modes allowing events to be interpreted in different ways
     pub fn run(&mut self) -> Result<(), String> {
-        self.render_screen(None)?;
+        self.render_screen(false, None)?;
         while self.ui_state.mode != Mode::Exit {
             match self.ui_state.mode {
                 Mode::Normal => self.run_normal_mode()?,
                 Mode::Command => match self.run_command_mode() {
                     // Upon success refresh
-                    Ok(()) => self.render_screen(None)?,
+                    Ok(()) => self.render_screen(true, None)?,
                     // Upon failure refresh and display error
-                    Err(e) => self.render_screen(Some(&e))?,
+                    Err(e) => self.render_screen(false, Some(&e))?,
                 },
                 Mode::Exit => continue,
             }
@@ -333,16 +333,16 @@ impl<'a> Program<'a> {
                     Action::ToggleFullscreen => {
                         self.toggle_fullscreen();
                         self.screen.update_fullscreen(self.ui_state.fullscreen)?;
-                        self.render_screen(None)?
+                        self.render_screen(false, None)?
                     }
-                    Action::ReRender => self.render_screen(None)?,
+                    Action::ReRender => self.render_screen(false, None)?,
                     Action::EnterCommandMode => {
                         self.ui_state.mode = Mode::Command;
                         break 'mainloop;
                     }
                     Action::ToggleFit => {
                         self.toggle_fit();
-                        self.render_screen(None)?
+                        self.render_screen(false, None)?
                     }
                     Action::Next => self.increment(1)?,
                     Action::Prev => self.decrement(1)?,

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -148,6 +148,10 @@ impl<'a> Program<'a> {
         if index >= self.paths.max_viewable && self.paths.index != 0 {
             self.paths.index -= 1;
         }
+        // Decrease max viewable if another image won't take the deleted's place
+        if self.paths.images.len() <= self.paths.max_viewable {
+            self.paths.max_viewable -= 1;
+        }
     }
 
     fn decrement(&mut self, step: usize) -> Result<(), String> {
@@ -251,10 +255,14 @@ impl<'a> Program<'a> {
                 e.to_string()
             ));
         }
-
         // Only if successful, remove image from tracked images
         self.remove_image(self.paths.index);
         self.screen.dirty = true;
+
+        // If index is greater than or equal to max_viewable set it to it - 1
+        if self.paths.index >= self.paths.max_viewable && self.paths.max_viewable != 0 {
+            self.paths.index = self.paths.max_viewable - 1;
+        }
 
         // Moving the image automatically advanced to next image
         // Adjust our view to reflect this
@@ -290,6 +298,11 @@ impl<'a> Program<'a> {
         // Only if successful, remove image from tracked images
         self.remove_image(self.paths.index);
         self.screen.dirty = true;
+
+        // If index is greater than or equal to max_viewable set it to it - 1
+        if self.paths.index >= self.paths.max_viewable && self.paths.max_viewable != 0 {
+            self.paths.index = self.paths.max_viewable - 1;
+        }
 
         // Removing the image automatically advanced to next image
         // Adjust our view to reflect this

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -336,7 +336,7 @@ impl<'a> Program<'a> {
                         self.render_screen(false, None)?
                     }
                     Action::ReRender => self.render_screen(false, None)?,
-                    Action::EnterCommandMode => {
+                    Action::SwitchCommandMode => {
                         self.ui_state.mode = Mode::Command;
                         break 'mainloop;
                     }

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -104,8 +104,6 @@ impl<'a> Program<'a> {
                 actual_max_viewable: max_length,
             },
             ui_state: ui::State {
-                left_shift: false,
-                right_shift: false,
                 render_infobar: true,
                 render_help: false,
                 actual_size: false,

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -309,7 +309,10 @@ impl<'a> Program<'a> {
         'main_loop: loop {
             let mode = &self.ui_state.mode.clone();
             match mode {
-                Mode::Normal => self.run_normal_mode()?,
+                Mode::Normal => {
+                    self.run_normal_mode()?;
+                    self.render_screen(true)?;
+                }
                 Mode::Command(..) => {
                     self.run_command_mode()?;
                     // Force renders in order to remove "Command" and other info from bar

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -49,6 +49,7 @@ impl<'a> Program<'a> {
     ) -> Result<Program<'a>, String> {
         let mut images = args.files;
         let dest_folder = args.dest_folder;
+        let changed_dest_folder = dest_folder == PathBuf::from("./keep");
         let reverse = args.reverse;
         let sort_order = args.sort_order;
         let max_length = args.max_length;
@@ -62,7 +63,7 @@ impl<'a> Program<'a> {
         let sorter = Sorter::new(sort_order, reverse);
         sorter.sort(&mut images);
 
-        let current_dir = match std::env::current_dir() {
+        let base_dir = match std::env::current_dir() {
             Ok(c) => c,
             Err(_) => PathBuf::new(),
         };
@@ -98,8 +99,9 @@ impl<'a> Program<'a> {
             paths: Paths {
                 images,
                 dest_folder,
+                changed_dest_folder,
                 index: 0,
-                current_dir,
+                base_dir,
                 max_viewable,
                 actual_max_viewable: max_length,
             },

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -104,10 +104,6 @@ impl<'a> Program<'a> {
     }
 
     fn render_infobar(&mut self, msg: Option<&str>) -> Result<(), String> {
-        let msg = match msg {
-            Some(msg) => msg,
-            None => "",
-        };
         let text = infobar::Text::update(&self.paths, msg);
         // Load the filename texture
         let filename_surface = self

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -13,15 +13,19 @@ const LINE_PADDING: i32 = 5;
 impl<'a> Program<'a> {
     /// render_screen is the main render function that delegates rendering every thing that needs be
     /// rendered
-    pub fn render_screen(&mut self, msg: Option<&str>) -> Result<(), String> {
+    pub fn render_screen(
+        &mut self,
+        force_render: bool,
+        infobar_msg: Option<&str>,
+    ) -> Result<(), String> {
         self.screen.canvas.set_draw_color(dark_grey());
         if self.paths.images.is_empty() {
             return self.render_blank();
         }
         self.screen.canvas.clear();
-        self.render_image()?;
+        self.render_image(force_render)?;
         if self.ui_state.render_infobar {
-            self.render_infobar(msg)?;
+            self.render_infobar(infobar_msg)?;
         }
         if self.ui_state.render_help {
             self.render_help()?;
@@ -32,8 +36,8 @@ impl<'a> Program<'a> {
         Ok(())
     }
 
-    fn render_image(&mut self) -> Result<(), String> {
-        self.set_image_texture()?;
+    fn render_image(&mut self, force_render: bool) -> Result<(), String> {
+        self.set_image_texture(force_render)?;
         match self.screen.last_texture {
             Some(_) => (),
             None => return Ok(()),
@@ -63,10 +67,11 @@ impl<'a> Program<'a> {
         Ok(())
     }
 
-    fn set_image_texture(&mut self) -> Result<(), String> {
+    fn set_image_texture(&mut self, force_render: bool) -> Result<(), String> {
         if self.paths.index == self.screen.last_index
             && self.screen.last_texture.is_some()
             && !self.screen.dirty
+            && !force_render
         {
             return Ok(());
         }

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -20,7 +20,7 @@ impl<'a> Program<'a> {
     ) -> Result<(), String> {
         self.screen.canvas.set_draw_color(dark_grey());
         if self.paths.images.is_empty() {
-            return self.render_blank();
+            return self.render_blank(infobar_msg);
         }
         self.screen.canvas.clear();
         self.render_image(force_render)?;
@@ -263,10 +263,10 @@ impl<'a> Program<'a> {
         Ok(())
     }
 
-    fn render_blank(&mut self) -> Result<(), String> {
+    fn render_blank(&mut self, infobar_msg: Option<&str>) -> Result<(), String> {
         self.screen.canvas.clear();
         if self.ui_state.render_infobar {
-            self.render_infobar(None)?;
+            self.render_infobar(infobar_msg)?;
         }
         if self.ui_state.render_help {
             self.render_help()?;

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -13,19 +13,15 @@ const LINE_PADDING: i32 = 5;
 impl<'a> Program<'a> {
     /// render_screen is the main render function that delegates rendering every thing that needs be
     /// rendered
-    pub fn render_screen(
-        &mut self,
-        force_render: bool,
-        infobar_msg: Option<&str>,
-    ) -> Result<(), String> {
+    pub fn render_screen(&mut self, force_render: bool) -> Result<(), String> {
         self.screen.canvas.set_draw_color(dark_grey());
         if self.paths.images.is_empty() {
-            return self.render_blank(infobar_msg);
+            return self.render_blank();
         }
         self.screen.canvas.clear();
         self.render_image(force_render)?;
         if self.ui_state.render_infobar {
-            self.render_infobar(infobar_msg)?;
+            self.render_infobar()?;
         }
         if self.ui_state.render_help {
             self.render_help()?;
@@ -108,8 +104,8 @@ impl<'a> Program<'a> {
         src_dims.x > dest_dims.x || src_dims.y > dest_dims.y
     }
 
-    fn render_infobar(&mut self, msg: Option<&str>) -> Result<(), String> {
-        let text = infobar::Text::update(&self.paths, msg);
+    fn render_infobar(&mut self) -> Result<(), String> {
+        let text = infobar::Text::update(&self.ui_state.mode, &self.paths);
         // Load the filename texture
         let filename_surface = self
             .screen
@@ -263,10 +259,10 @@ impl<'a> Program<'a> {
         Ok(())
     }
 
-    fn render_blank(&mut self, infobar_msg: Option<&str>) -> Result<(), String> {
+    fn render_blank(&mut self) -> Result<(), String> {
         self.screen.canvas.clear();
         if self.ui_state.render_infobar {
-            self.render_infobar(infobar_msg)?;
+            self.render_infobar()?;
         }
         if self.ui_state.render_help {
             self.render_help()?;

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -313,7 +313,7 @@ fn help_text() -> Vec<&'static str> {
         "| Delete OR d      | Delete image from it's location                        |",
         "| t                | Toggle information bar                                 |",
         "| f OR F11         | Toggle fullscreen mode                                 |",
-        "| h                | Toggle help box                                        |",
+        "| ?                | Toggle help box                                        |",
         "| z OR Left Click  | Toggle actual size vs scaled image                     |",
         "| . (period)       | Repeat last action                                     |",
         "+------------------+--------------------------------------------------------+",

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -13,7 +13,7 @@ const LINE_PADDING: i32 = 5;
 impl<'a> Program<'a> {
     /// render_screen is the main render function that delegates rendering every thing that needs be
     /// rendered
-    pub fn render_screen(&mut self) -> Result<(), String> {
+    pub fn render_screen(&mut self, msg: Option<&str>) -> Result<(), String> {
         self.screen.canvas.set_draw_color(dark_grey());
         if self.paths.images.is_empty() {
             return self.render_blank();
@@ -21,7 +21,7 @@ impl<'a> Program<'a> {
         self.screen.canvas.clear();
         self.render_image()?;
         if self.ui_state.render_infobar {
-            self.render_infobar()?;
+            self.render_infobar(msg)?;
         }
         if self.ui_state.render_help {
             self.render_help()?;
@@ -103,13 +103,17 @@ impl<'a> Program<'a> {
         src_dims.x > dest_dims.x || src_dims.y > dest_dims.y
     }
 
-    fn render_infobar(&mut self) -> Result<(), String> {
-        let text = infobar::Text::from(&self.paths);
+    fn render_infobar(&mut self, msg: Option<&str>) -> Result<(), String> {
+        let msg = match msg {
+            Some(msg) => msg,
+            None => "",
+        };
+        let text = infobar::Text::update(&self.paths, msg);
         // Load the filename texture
         let filename_surface = self
             .screen
             .font
-            .render(&text.current_image)
+            .render(&text.information)
             .blended(text_color())
             .map_err(|e| e.to_string())?;
         let filename_texture = self
@@ -122,7 +126,7 @@ impl<'a> Program<'a> {
         let index_surface = self
             .screen
             .font
-            .render(&text.index)
+            .render(&text.mode)
             .blended(text_color())
             .map_err(|e| e.to_string())?;
         let index_texture = self
@@ -261,7 +265,7 @@ impl<'a> Program<'a> {
     fn render_blank(&mut self) -> Result<(), String> {
         self.screen.canvas.clear();
         if self.ui_state.render_infobar {
-            self.render_infobar()?;
+            self.render_infobar(None)?;
         }
         if self.ui_state.render_help {
             self.render_help()?;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -105,47 +105,44 @@ pub fn process_normal_mode<'a>(state: &mut State<'a>, event: &Event) -> Action<'
     match event {
         Event::Quit { .. } => Action::Quit,
 
-        Event::KeyDown {
-            keycode: Some(k),
-            scancode: Some(scan),
-            ..
-        } => match k {
-            C => state.process_action(Action::Copy),
-            D | Delete => state.process_action(Action::Delete),
-            F | F11 => state.process_action(Action::ToggleFullscreen),
-            G => {
-                if state.left_shift || state.right_shift {
-                    state.process_action(Action::Last)
-                } else {
-                    state.process_action(Action::First)
-                }
-            }
-            H => {
+        Event::TextInput { text, .. } => match text.as_str() {
+            "c" => state.process_action(Action::Copy),
+            "d" => state.process_action(Action::Delete),
+            "f" => state.process_action(Action::ToggleFullscreen),
+            "g" => state.process_action(Action::First),
+            "G" => state.process_action(Action::Last),
+            "?" => {
                 state.render_help = !state.render_help;
                 state.process_action(Action::ReRender)
             }
-            J | Right => state.process_action(Action::Next),
-            K | Left => state.process_action(Action::Prev),
-            M => state.process_action(Action::Move),
-            Q | Escape => Action::Quit,
-            T => {
+            "j" => state.process_action(Action::Next),
+            "k" => state.process_action(Action::Prev),
+            "m" => state.process_action(Action::Move),
+            "q" => Action::Quit,
+            "t" => {
                 state.render_infobar = !state.render_infobar;
                 state.process_action(Action::ReRender)
             }
-            W | PageUp => state.process_action(Action::SkipForward),
-            B | PageDown => state.process_action(Action::SkipBack),
-            Z => state.process_action(Action::ToggleFit),
+            "w" => state.process_action(Action::SkipForward),
+            "b" => state.process_action(Action::SkipBack),
+            "z" => state.process_action(Action::ToggleFit),
+            ":" => Action::SwitchCommandMode,
+            _ => Action::Noop,
+        },
+
+        Event::KeyDown {
+            keycode: Some(k), ..
+        } => match k {
+            Delete => state.process_action(Action::Delete),
+            F11 => state.process_action(Action::ToggleFullscreen),
+            Right => state.process_action(Action::Next),
+            Left => state.process_action(Action::Prev),
+            Escape => Action::Quit,
+            PageUp => state.process_action(Action::SkipForward),
+            PageDown => state.process_action(Action::SkipBack),
             Home => Action::First,
             End => Action::Last,
             Period => state.last_action.clone(),
-            Colon => Action::SwitchCommandMode,
-            Semicolon => {
-                if state.left_shift || state.right_shift {
-                    Action::SwitchCommandMode
-                } else {
-                    Action::Noop
-                }
-            }
             LShift => {
                 state.left_shift = true;
                 Action::Noop
@@ -154,17 +151,7 @@ pub fn process_normal_mode<'a>(state: &mut State<'a>, event: &Event) -> Action<'
                 state.right_shift = true;
                 Action::Noop
             }
-            _ => {
-                // convert scancode to keycode via virtual mapping
-                let keycode = match sdl2::keyboard::Keycode::from_scancode(*scan) {
-                    Some(keycode) => keycode,
-                    Option::None => return Action::Noop,
-                };
-                match keycode {
-                    Colon => Action::SwitchCommandMode,
-                    _ => Action::Noop,
-                }
-            }
+            _ => Action::Noop,
         },
 
         Event::KeyUp {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -49,12 +49,16 @@ pub enum Action<'a> {
 }
 
 /// Modal setting for Program, this dictates the commands that are available to the user
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub enum Mode {
     /// Default mode, allows the removal, traversal, move, and copy of images
     Normal,
     /// Mode that is built off of user input, allows switching the current glob
-    Command,
+    /// string is the input to display on the infobar
+    Command(String),
+    /// Mode that is meant to display errors to the user through the infobar
+    /// string is the input to display on the infobar
+    Error(String),
     /// Terminate condition, if this mode is set the program will stop execution
     Exit,
 }
@@ -126,9 +130,9 @@ pub fn process_normal_mode<'a>(state: &mut State<'a>, event: &Event) -> Action<'
                 state.render_infobar = !state.render_infobar;
                 state.process_action(Action::ReRender)
             }
-            W | PageUp => Action::SkipForward,
-            B | PageDown => Action::SkipBack,
-            Z => Action::ToggleFit,
+            W | PageUp => state.process_action(Action::SkipForward),
+            B | PageDown => state.process_action(Action::SkipBack),
+            Z => state.process_action(Action::ToggleFit),
             Home => Action::First,
             End => Action::Last,
             Period => state.last_action.clone(),
@@ -136,7 +140,6 @@ pub fn process_normal_mode<'a>(state: &mut State<'a>, event: &Event) -> Action<'
                 if state.left_shift || state.right_shift {
                     Action::SwitchCommandMode
                 } else {
-                    // placeholder for any feature that uses ';'
                     Action::Noop
                 }
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -65,10 +65,6 @@ pub enum Mode {
 
 /// State tracks events that will change the behaviour of future events. Such as key modifiers.
 pub struct State<'a> {
-    /// left_shift tracks whether or not the left shift key is pressed.
-    pub left_shift: bool,
-    /// right_shift tracks whether or not the right shift key is pressed.
-    pub right_shift: bool,
     /// render_infobar determines whether or not the info bar should be rendered.
     pub render_infobar: bool,
     /// render_help determines whether or not the help info should be rendered.
@@ -143,28 +139,6 @@ pub fn process_normal_mode<'a>(state: &mut State<'a>, event: &Event) -> Action<'
             Home => Action::First,
             End => Action::Last,
             Period => state.last_action.clone(),
-            LShift => {
-                state.left_shift = true;
-                Action::Noop
-            }
-            RShift => {
-                state.right_shift = true;
-                Action::Noop
-            }
-            _ => Action::Noop,
-        },
-
-        Event::KeyUp {
-            keycode: Some(k), ..
-        } => match k {
-            LShift => {
-                state.left_shift = false;
-                Action::Noop
-            }
-            RShift => {
-                state.right_shift = false;
-                Action::Noop
-            }
             _ => Action::Noop,
         },
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -14,6 +14,8 @@ pub enum Action {
     /// ReRender indicates the app should re-render in response to this event (such as a window
     /// resize)
     ReRender,
+    /// Switches modes from visual to command mode to enter queries such as "newglob"/"ng"
+    EnterCommandMode,
     /// The app should switch its current image viewing preference of fitting the
     /// image to screen or displaying the actual size as actual size
     ToggleFit,
@@ -95,6 +97,14 @@ pub fn event_action(state: &mut State, event: &Event) -> Action {
             Z => Action::ToggleFit,
             Home => Action::First,
             End => Action::Last,
+            Semicolon => {
+                if state.left_shift || state.right_shift {
+                    Action::EnterCommandMode
+                } else {
+                    // placeholder for any feature that uses ';'
+                    Action::Noop
+                }
+            }
             LShift => {
                 state.left_shift = true;
                 Action::Noop

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -14,8 +14,8 @@ pub enum Action {
     /// ReRender indicates the app should re-render in response to this event (such as a window
     /// resize)
     ReRender,
-    /// Switches modes from visual to command mode to enter queries such as "newglob"/"ng"
-    EnterCommandMode,
+    /// Switches modes from normal to command mode to enter queries such as "newglob"/"ng"
+    CommandMode,
     /// The app should switch its current image viewing preference of fitting the
     /// image to screen or displaying the actual size as actual size
     ToggleFit,
@@ -99,7 +99,7 @@ pub fn event_action(state: &mut State, event: &Event) -> Action {
             End => Action::Last,
             Semicolon => {
                 if state.left_shift || state.right_shift {
-                    Action::EnterCommandMode
+                    Action::CommandMode
                 } else {
                     // placeholder for any feature that uses ';'
                     Action::Noop

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,13 +15,13 @@ pub enum Action<'a> {
     /// resize)
     ReRender,
     /// Switches modes from normal to command mode to enter queries such as "newglob"/"ng"
-    EnterCommandMode,
+    SwitchCommandMode,
     /// Indicates user hit the backspace, program input should be truncated accordinly
     Backspace,
     /// User entered input from the keyboard
     KeyboardInput(&'a str),
     /// switches modes back to normal mode
-    ExitCommandMode,
+    SwitchNormalMode,
     /// The app should switch its current image viewing preference of fitting the
     /// image to screen or displaying the actual size as actual size
     ToggleFit,
@@ -118,7 +118,7 @@ pub fn process_normal_mode<'a>(state: &mut State, event: &Event) -> Action<'a> {
             End => Action::Last,
             Semicolon => {
                 if state.left_shift || state.right_shift {
-                    Action::EnterCommandMode
+                    Action::SwitchCommandMode
                 } else {
                     // placeholder for any feature that uses ';'
                     Action::Noop
@@ -176,9 +176,9 @@ pub fn process_command_mode<'a>(event: &'a Event) -> Action<'a> {
             ..
         } => match code {
             Keycode::Backspace => Action::Backspace,
-            Keycode::Escape => Action::ExitCommandMode,
+            Keycode::Escape => Action::SwitchNormalMode,
             // User is done entering input
-            Keycode::Return | Keycode::Return2 | Keycode::KpEnter => Action::ExitCommandMode,
+            Keycode::Return | Keycode::Return2 | Keycode::KpEnter => Action::SwitchNormalMode,
             _ => Action::Noop,
         },
         Event::Window { win_event, .. } => match win_event {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -183,7 +183,7 @@ pub fn process_normal_mode<'a>(state: &mut State<'a>, event: &Event) -> Action<'
 }
 
 /// Processes event information for Command mode, and returns them as Actions
-pub fn process_command_mode<'a>(event: &'a Event) -> Action<'a> {
+pub fn process_command_mode(event: &Event) -> Action {
     use sdl2::event::WindowEvent;
     use sdl2::keyboard::Keycode;
 


### PR DESCRIPTION
### Features
 * infobar displays command mode input, and errors
#### Command Mode Features
     * h/help
     * q/quit
     * sort
     * ng/newglob, handles `~` and `$HOME` properly and directories are assumed to be `/dir/*`
     * df/destfolder
     * r/reverse
     * m/max

### Known bugs: 

* In command mode: cannot type `:` due to the event buffer not being cleared this character is ignored, because it will commonly be added on first loop of `get_command` in `/src/program/command_mode.rs`

* When program starts in a directory that has no images, Command mode isn't properly displayed on the infobar

### Future Fixes
 * Decouple the rendering so that I and @gurgalex can update the infobar without having to pass the info to display to `render_screen`, allow updating of smaller components like the infobar before calling render or some other solution.

* Force rendering, workaround solution being used for cases like `newglob` which should re-render when the current viewed image isn't in the new glob.

@gurgalex Here's how I'm handling it, few bugs I wanted to iron out before setting up the pull request