### PR TITLE
Normalize relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Set the maximum number of images to be displayed `m` or `--max` flag. 0 means in
 | Command                     | Action                                                   |
 |-----------------------------|----------------------------------------------------------|
 | ng OR newglob [glob]        | **Required argument** the new glob/directory/file        |
-| ? OR help                   | Toggle fullscreen mode                                   |
+| ? OR help                   | Toggle help box                                          |
 | q OR quit                   | Quit                                                     |
 | sort (method)               | *Optional argument* the new method to sort by            |
 | df OR destfolder [path]     | **Required argument** new folder to move/copy images to  |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@
 //!
 //! The cli module is used for setting up the command line app and parsing the arguments.
 
+use crate::paths::{normalize_path, push_image_path};
 use crate::sort::SortOrder;
 use clap::{App, Arg};
 use std::path::PathBuf;
@@ -80,7 +81,7 @@ pub fn cli() -> Result<Args, String> {
     match matches.values_of("paths") {
         Some(path_matches) => {
             for path in path_matches {
-                push_image_path(&mut files, PathBuf::from(path));
+                push_image_path(&mut files, normalize_path(&PathBuf::from(path)));
             }
         }
         None => {
@@ -122,15 +123,4 @@ pub fn cli() -> Result<Args, String> {
         max_length,
         fullscreen,
     })
-}
-
-pub(crate) fn push_image_path(v: &mut Vec<PathBuf>, p: PathBuf) {
-    if let Some(ext) = p.extension() {
-        if let Some(ext_str) = ext.to_str() {
-            let low = ext_str.to_string().to_lowercase();
-            if low == "jpg" || low == "jpeg" || low == "png" || low == "bmp" || low == "webp" {
-                v.push(p)
-            }
-        }
-    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@
 //!
 //! The cli module is used for setting up the command line app and parsing the arguments.
 
-use crate::paths::{normalize_path, push_image_path};
+use crate::paths::push_image_path;
 use crate::sort::SortOrder;
 use clap::{App, Arg};
 use std::path::PathBuf;
@@ -81,7 +81,12 @@ pub fn cli() -> Result<Args, String> {
     match matches.values_of("paths") {
         Some(path_matches) => {
             for path in path_matches {
-                push_image_path(&mut files, normalize_path(&PathBuf::from(path)));
+                let pathbuf = PathBuf::from(path);
+                // normalize path
+                match pathbuf.canonicalize() {
+                    Ok(path) => push_image_path(&mut files, path),
+                    Err(e) => eprintln!("{}", e),
+                }
             }
         }
         None => {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -36,8 +36,7 @@ pub fn normalize_path(path: &PathBuf) -> PathBuf {
     use std::path::Component;
 
     let mut normalized_path = PathBuf::new();
-    let mut components = path.components();
-    while let Some(component) = components.next() {
+    for component in path.components() {
         // skip '.'
         if component == Component::CurDir {
             continue;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,5 +1,5 @@
 //! Paths contains the Paths struct which contains all path related information required for the
-//! running of the program.
+//! running of the program. As well as utility functions used to add paths and normalize paths
 
 use std::path::PathBuf;
 
@@ -9,8 +9,6 @@ pub struct Paths {
     pub images: Vec<PathBuf>,
     /// dest_folder is the path of the destination folder for moving and copying images.
     pub dest_folder: PathBuf,
-    /// dest_folder was modified from the default keep through Command mode df or destfolder
-    pub changed_dest_folder: bool,
     /// current_dir is the path of the current directory where the program was launched from
     pub base_dir: PathBuf,
     /// index is the index of the images vector of the current image to be displayed.
@@ -19,4 +17,36 @@ pub struct Paths {
     pub max_viewable: usize,
     /// Actual length the user said was maximum for images
     pub actual_max_viewable: usize,
+}
+
+/// Pushes images to vector (v) if the path (p) extension is a valid image extension
+pub fn push_image_path(v: &mut Vec<PathBuf>, p: PathBuf) {
+    if let Some(ext) = p.extension() {
+        if let Some(ext_str) = ext.to_str() {
+            let low = ext_str.to_string().to_lowercase();
+            if low == "jpg" || low == "jpeg" || low == "png" || low == "bmp" || low == "webp" {
+                v.push(p)
+            }
+        }
+    }
+}
+
+/// Constructs a normalized_path removing '.', parent_dir/'..'
+pub fn normalize_path(path: &PathBuf) -> PathBuf {
+    use std::path::Component;
+
+    let mut normalized_path = PathBuf::new();
+    let mut components = path.components();
+    while let Some(component) = components.next() {
+        // skip '.'
+        if component == Component::CurDir {
+            continue;
+        // remove last appended file '..'
+        } else if component == Component::ParentDir {
+            normalized_path.pop();
+        } else {
+            normalized_path.push(component);
+        }
+    }
+    normalized_path
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -30,22 +30,3 @@ pub fn push_image_path(v: &mut Vec<PathBuf>, p: PathBuf) {
         }
     }
 }
-
-/// Constructs a normalized_path removing '.', parent_dir/'..'
-pub fn normalize_path(path: &PathBuf) -> PathBuf {
-    use std::path::Component;
-
-    let mut normalized_path = PathBuf::new();
-    for component in path.components() {
-        // skip '.'
-        if component == Component::CurDir {
-            continue;
-        // remove last appended file '..'
-        } else if component == Component::ParentDir {
-            normalized_path.pop();
-        } else {
-            normalized_path.push(component);
-        }
-    }
-    normalized_path
-}

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -1,7 +1,7 @@
 //! File that contains Command mode functionality, command mode is a mode that allows verbose input
 //! from the user to perform tasks or edit stored data in the application during runtime
 use super::Program;
-use crate::paths::{normalize_path, push_image_path};
+use crate::paths::push_image_path;
 use crate::sort::SortOrder;
 use crate::ui::{process_command_mode, Action, Mode};
 use shellexpand::full;
@@ -88,7 +88,7 @@ fn glob_path(path: &str, base_dir: &PathBuf) -> Result<(PathBuf, Vec<PathBuf>), 
     // remove env vars and "\ "
     let sanitized_dir = sanitize_path(path, base_dir)?;
     // normalized path removing ".." and "."
-    let base_dir = normalize_path(&sanitized_dir);
+    let base_dir = sanitized_dir.canonicalize().map_err(|e| e.to_string())?;
 
     // Convert base_dir to a glob
     let globable_path = {

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -49,7 +49,6 @@ impl<'a> Program<'a> {
     ) -> Result<Program<'a>, String> {
         let mut images = args.files;
         let dest_folder = args.dest_folder;
-        let changed_dest_folder = dest_folder == PathBuf::from("./keep");
         let reverse = args.reverse;
         let sort_order = args.sort_order;
         let max_length = args.max_length;
@@ -99,7 +98,6 @@ impl<'a> Program<'a> {
             paths: Paths {
                 images,
                 dest_folder,
-                changed_dest_folder,
                 index: 0,
                 base_dir,
                 max_viewable,


### PR DESCRIPTION
So in the previous PR you guys merged while I was on lunch and was fixing this issue :joy: 

I fixed the issue with the `README.md` and reverted to the previous design for the `./keep` file

### Issue: 
Paths aren't normalized, so paths on the infobar could have unnecessary bloat.

`newglob` had this issue and so did passing paths from command line. I also moved the commonly used functions like `cli.rs`'s `push_image_path` and `normalize_paths` into `paths.rs` since they're directly related and both are utility functions. 

This made it really difficult to navigate using newglob to move around.

### Issues with current implementation:
For instance if you cd into a symlink to another directory, typing `cd ..`afterwards won't bring you back up to the directory the symlink is contained in, but just the higher directory of what the symlink points to. It's impossible to implement the proper reverse following without severely hurting performance. Read more [here](https://doc.rust-lang.org/1.31.0/std/path/struct.PathBuf.html#method.components)

### Examples:
`~/Pictures/././././../Pictures/*` => `~/Pictures/*`