### PR TITLE
Reverted changes made to destfolder in #58

### DIFF
--- a/src/paths.rs
+++ b/src/paths.rs
@@ -9,8 +9,6 @@ pub struct Paths {
     pub images: Vec<PathBuf>,
     /// dest_folder is the path of the destination folder for moving and copying images.
     pub dest_folder: PathBuf,
-    /// dest_folder was modified from the default keep through Command mode df or destfolder
-    pub changed_dest_folder: bool,
     /// current_dir is the path of the current directory where the program was launched from
     pub base_dir: PathBuf,
     /// index is the index of the images vector of the current image to be displayed.

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -335,9 +335,6 @@ impl<'a> Program<'a> {
                     return Ok(());
                 }
                 self.newglob(&arguments);
-                if !self.paths.changed_dest_folder {
-                    self.paths.dest_folder = self.paths.base_dir.join("keep");
-                }
             }
             Commands::Help => {
                 self.ui_state.render_help = !self.ui_state.render_help;
@@ -367,7 +364,6 @@ impl<'a> Program<'a> {
                         return Ok(());
                     }
                 }
-                self.paths.changed_dest_folder = true;
             }
             Commands::MaximumImages => {
                 if arguments.is_empty() {

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -49,7 +49,6 @@ impl<'a> Program<'a> {
     ) -> Result<Program<'a>, String> {
         let mut images = args.files;
         let dest_folder = args.dest_folder;
-        let changed_dest_folder = dest_folder == PathBuf::from("./keep");
         let reverse = args.reverse;
         let sort_order = args.sort_order;
         let max_length = args.max_length;
@@ -99,7 +98,6 @@ impl<'a> Program<'a> {
             paths: Paths {
                 images,
                 dest_folder,
-                changed_dest_folder,
                 index: 0,
                 base_dir,
                 max_viewable,


### PR DESCRIPTION
* Destfolder defaults to the directory the user starts riv in and does
not change when newglobbing into a different directory