### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "riv"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "riv"
-version = "0.2.0"
-authors = ["davejkane", "gurgalex"]
+version = "0.3.0"
+authors = ["davejkane", "gurgalex", "nickhackman"]
 edition = "2018"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 
 * **[Dave Kane](https://github.com/Davejkane)** - *Initial Implementation*
 * **[Alex Gurganus](https://github.com/gurgalex)** - *Implementing core features since 0.1.0*
+* **[Nick Hackman](https://github.com/nickhackman)** - *Implementing core features since 0.2.0*
 
 See also the list of [contributors](https://github.com/davejkane/riv/contributors) who participated in this project.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ pub struct Args {
 pub fn cli() -> Result<Args, String> {
     let mut files = Vec::new();
     let matches = App::new("riv")
-        .version("0.2.0")
+        .version("0.3.0")
         .about("The command line image viewer")
         .arg(
             Arg::with_name("paths")

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -137,21 +137,24 @@ impl<'a> Program<'a> {
 
     // Calculates the scale required to fit large images to screen
     fn calculate_scale_for_fit(&self) -> f32 {
-        let tex = self.screen.last_texture.as_ref().unwrap();
-        let query = tex.query();
-        let (src_x, src_y) = (query.width, query.height);
-        let target = self.screen.canvas.viewport();
-        let (dst_x, dst_y) = (target.width(), target.height());
-        // case 1: both source dimensions smaller
-        if src_x < dst_x && src_y < dst_y {
-            return 1.0;
+        if let Some(tex) = self.screen.last_texture.as_ref() {
+            let query = tex.query();
+            let (src_x, src_y) = (query.width, query.height);
+            let target = self.screen.canvas.viewport();
+            let (dst_x, dst_y) = (target.width(), target.height());
+            // case 1: both source dimensions smaller
+            if src_x < dst_x && src_y < dst_y {
+                return 1.0;
+            }
+            // case 2: source aspect ratio is larger
+            if src_x as f32 / src_y as f32 > dst_x as f32 / dst_y as f32 {
+                return dst_x as f32 / src_x as f32;
+            }
+            // case 3: source aspect ratio is smaller
+            dst_y as f32 / src_y as f32
+        } else {
+            1.0
         }
-        // case 2: source aspect ratio is larger
-        if src_x as f32 / src_y as f32 > dst_x as f32 / dst_y as f32 {
-            return dst_x as f32 / src_x as f32;
-        }
-        // case 3: source aspect ratio is smaller
-        dst_y as f32 / src_y as f32
     }
 
     fn increment(&mut self, step: usize) -> Result<(), String> {


### PR DESCRIPTION
This bumps the version in the relevant places to 0.3.0 in preparation for release. This also closes [#80](https://github.com/Davejkane/riv/issues/80)