### PR TITLE
Rotate image

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Set a sorting order with the `s` or `--sort` flag, case insensitive.
 | g/G        | Home/End                   | First/Last Image (55G jumps to the 55th image)      |
 | m          |                            | Move image to destination folder (default ./keep)   |
 | c          |                            | Copy image to destination folder (default ./keep)   |
-| d          | Delete                     | Delete image from it's location                     |
+| d          | Delete                     | Delete image from its location                      |
 | t          |                            | Toggle information bar                              |
 | f          | F11                        | Toggle fullscreen mode                              |
 | ?          |                            | Toggle help box                                     |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Set a sorting order with the `s` or `--sort` flag, case insensitive.
 | q          | Esc                        | Quit                                                |
 | k/j        | Left/Right                 | Previous/Next Image                                 |
 | i/o        | Up/Down                    | Zoom in/out                                         |
+| r/R        |                            | Rotate image clockwise/counterclockwise             |
 | H, J, K, L | Shift + Up/Down/Left/Right | Pan left/down/up/right                              |
 | h          |                            | Flip image horizontally                             |
 | v          |                            | Flip image vertically                               |

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -573,6 +573,9 @@ impl<'a> Program<'a> {
 
     /// Processes Normal Mode Actions
     /// Ok result tells whether to continue or break out of the current Mode
+    // Allow cognitive complexity lint since we need to match every Action
+    // Note: complexity could be simplified by splittng out Command mode and Normal mode actions
+    #[allow(clippy::cognitive_complexity)]
     fn dispatch_normal(&mut self, process_action: ProcessAction) -> Result<CompleteType, String> {
         match process_action {
             ProcessAction { action, times } => match action {

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -10,7 +10,7 @@ use crate::cli;
 use crate::paths::{Paths, PathsBuilder};
 use crate::screen::Screen;
 use crate::sort::Sorter;
-use crate::ui::{self, Action, Mode, PanAction, ProcessAction, ZoomAction};
+use crate::ui::{self, Action, Mode, PanAction, ProcessAction, RotationDirection, ZoomAction};
 use core::cmp;
 use fs_extra::file::copy;
 use fs_extra::file::move_file;
@@ -574,8 +574,6 @@ impl<'a> Program<'a> {
     /// Processes Normal Mode Actions
     /// Ok result tells whether to continue or break out of the current Mode
     fn dispatch_normal(&mut self, process_action: ProcessAction) -> Result<CompleteType, String> {
-        //let action = self.ui_state.register.cur_action.action;
-        //let times = self.ui_state.register.cur_action.times;
         match process_action {
             ProcessAction { action, times } => match action {
                 Action::Quit => {
@@ -608,6 +606,14 @@ impl<'a> Program<'a> {
                 Action::SkipBack => self.skip_backward(times)?,
                 Action::Zoom(ZoomAction::In) => self.zoom_in(times)?,
                 Action::Zoom(ZoomAction::Out) => self.zoom_out(times)?,
+                Action::Rotate(RotationDirection::Clockwise) => {
+                    self.ui_state.rot_angle = self.ui_state.rot_angle.rot_clockwise();
+                    self.render_screen(false)?;
+                }
+                Action::Rotate(RotationDirection::CounterClockwise) => {
+                    self.ui_state.rot_angle = self.ui_state.rot_angle.rot_clockclockwise();
+                    self.render_screen(false)?;
+                }
                 Action::Pan(PanAction::Left) => self.pan_left(times)?,
                 Action::Pan(PanAction::Right) => self.pan_right(times)?,
                 Action::Pan(PanAction::Up) => self.pan_up(times)?,

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -406,7 +406,7 @@ fn normal_help_text() -> Vec<&'static str> {
         "| g/G        | Home/End                   | First/Last Image (55G jumps to the 55th image)      |",
         "| m          |                            | Move image to destination folder (default ./keep)   |",
         "| c          |                            | Copy image to destination folder (default ./keep)   |",
-        "| d          | Delete                     | Delete image from it's location                     |",
+        "| d          | Delete                     | Delete image from its location                      |",
         "| t          |                            | Toggle information bar                              |",
         "| f          | F11                        | Toggle fullscreen mode                              |",
         "| ?          |                            | Toggle help box                                     |",

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -1,6 +1,6 @@
 use crate::infobar;
 use crate::program::{make_dst, Program};
-use crate::ui::{HelpRender, Mode};
+use crate::ui::{HelpRender, Mode, RotAngle};
 use sdl2::image::LoadTexture;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
@@ -54,11 +54,18 @@ impl<'a> Program<'a> {
             self.ui_state.pan_x,
             self.ui_state.pan_y,
         );
+
+        let angle = match self.ui_state.rot_angle {
+            RotAngle::Up => 0.0,
+            RotAngle::Right => 90.0,
+            RotAngle::Down => 180.0,
+            RotAngle::Left => 270.0,
+        };
         if let Err(e) = self.screen.canvas.copy_ex(
             &tex,
             None,
             dst,
-            0.0,
+            angle,
             None,
             self.ui_state.flip_horizontal,
             self.ui_state.flip_vertical,
@@ -100,12 +107,15 @@ impl<'a> Program<'a> {
         };
 
         // Set the default state for viewing of the image
-
         self.screen.last_texture = Some(texture);
         self.screen.dirty = false;
+        // fit to screen
         self.ui_state.scale = self.calculate_scale_for_fit();
+        // no offsets
         self.ui_state.pan_x = 0.0;
         self.ui_state.pan_y = 0.0;
+        // 0 degree rotation
+        self.ui_state.rot_angle = RotAngle::Up;
         Ok(())
     }
 

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -398,6 +398,7 @@ fn normal_help_text() -> Vec<&'static str> {
         "| q          | Esc                        | Quit                                                |",
         "| k/j        | Left/Right                 | Previous/Next Image                                 |",
         "| i/o        | Up/Down                    | Zoom in/out                                         |",
+        "| r/R        |                            | Rotate image clockwise/counterclockwise             |",
         "| H, J, K, L | Shift + Up/Down/Left/Right | Pan left/down/up/right                              |",
         "| h          |                            | Flip image horizontally                             |",
         "| v          |                            | Flip image vertically                               |",

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -308,26 +308,6 @@ impl<'a> Default for State<'a> {
 }
 
 impl<'a> State<'a> {
-    /*
-        /// Current rotation angle of image
-        pub fn rot_angle(&self) -> u16 {
-            self.rot_angle
-        }
-
-        /// Advance image rotation setting clockwise by `angle` degrees
-        pub fn rotate_clockwise(&mut self, angle: u16) {
-            self.rot_angle = (self.rot_angle + angle) % 360;
-        }
-
-        /// Decrease image rotation by `angle` degrees
-        pub fn rotate_counterclockwise(&mut self, angle: u16) {
-            self.rot_angle = match self.rot_angle.checked_sub(angle) {
-                Some(angle) => angle,
-                None => 360 - (angle % 360),
-            }
-        }
-    */
-
     /// Increases zoom scale. Does not render image
     pub fn zoom_in(&mut self, times: usize) {
         let zoom_factor: f32 = 1.1;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -50,6 +50,8 @@ pub enum Action<'a> {
     SkipBack,
     /// Zoom zooms in or out depending on the ZoomAction variant
     Zoom(ZoomAction),
+    /// Which direction to rotate image
+    Rotate(RotationDirection),
     /// Pan pans the picture in the direction of the PanAction variant
     Pan(PanAction),
     /// Copy indicates the app should copy the image in response to this event
@@ -60,6 +62,15 @@ pub enum Action<'a> {
     Delete,
     /// Noop indicates the app should not respond to this event
     Noop,
+}
+
+/// Direction to rotate image
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RotationDirection {
+    /// Instruct to rotate image clockwise
+    Clockwise,
+    /// Instruct to rotate image counterclockwise
+    CounterClockwise,
 }
 
 impl<'a> Default for Action<'a> {
@@ -231,11 +242,47 @@ pub struct State<'a> {
     pub flip_horizontal: bool,
     /// Image is flipped vertically from original state
     pub flip_vertical: bool,
+    /// Angle to rotate original image at
+    /// Only supports 90 degree increments specified in `RotAngle` enum
+    pub rot_angle: RotAngle,
     /// The time, from which to do a re-render will be base on.
     /// Use to clear infobar messages after inactivity
     pub rerender_time: Option<Instant>,
     /// Store
     pub register: Register<'a>,
+}
+
+/// Rotation angle for image
+pub enum RotAngle {
+    /// 0 degree rotation
+    Up,
+    /// 90 degree rotation
+    Right,
+    /// 180 degree rotation
+    Down,
+    /// 270 degree rotation
+    Left,
+}
+
+impl RotAngle {
+    /// Next state of rotation when rotated clockwise
+    pub fn rot_clockwise(&self) -> RotAngle {
+        match self {
+            RotAngle::Up => RotAngle::Right,
+            RotAngle::Right => RotAngle::Down,
+            RotAngle::Down => RotAngle::Left,
+            RotAngle::Left => RotAngle::Up,
+        }
+    }
+    /// Next state of rotation when rotated counterclockwise
+    pub fn rot_clockclockwise(&self) -> RotAngle {
+        match self {
+            RotAngle::Up => RotAngle::Left,
+            RotAngle::Left => RotAngle::Down,
+            RotAngle::Down => RotAngle::Right,
+            RotAngle::Right => RotAngle::Up,
+        }
+    }
 }
 
 impl<'a> Default for State<'a> {
@@ -251,6 +298,7 @@ impl<'a> Default for State<'a> {
             pan_y: 0.0,
             flip_horizontal: false,
             flip_vertical: false,
+            rot_angle: RotAngle::Up,
             rerender_time: None,
             register: Register {
                 ..Default::default()
@@ -260,6 +308,26 @@ impl<'a> Default for State<'a> {
 }
 
 impl<'a> State<'a> {
+    /*
+        /// Current rotation angle of image
+        pub fn rot_angle(&self) -> u16 {
+            self.rot_angle
+        }
+
+        /// Advance image rotation setting clockwise by `angle` degrees
+        pub fn rotate_clockwise(&mut self, angle: u16) {
+            self.rot_angle = (self.rot_angle + angle) % 360;
+        }
+
+        /// Decrease image rotation by `angle` degrees
+        pub fn rotate_counterclockwise(&mut self, angle: u16) {
+            self.rot_angle = match self.rot_angle.checked_sub(angle) {
+                Some(angle) => angle,
+                None => 360 - (angle % 360),
+            }
+        }
+    */
+
     /// Increases zoom scale. Does not render image
     pub fn zoom_in(&mut self, times: usize) {
         let zoom_factor: f32 = 1.1;
@@ -339,6 +407,9 @@ pub fn process_multi_normal_mode<'a>(
             "m" => (Action::Move, times).into(),
             "o" => (Action::Zoom(ZoomAction::Out), times).into(),
             "q" => MultiNormalAction::Quit,
+            "r" => (Action::Rotate(RotationDirection::Clockwise), times).into(),
+            "R" => (Action::Rotate(RotationDirection::CounterClockwise), times).into(),
+
             "t" => {
                 state.render_infobar = !state.render_infobar;
                 (Action::ReRender, times).into()
@@ -434,6 +505,8 @@ pub fn process_normal_mode<'a>(state: &mut State<'a>, event: &Event) -> ProcessA
             "m" => Action::Move.into(),
             "o" => Action::Zoom(ZoomAction::Out).into(),
             "q" => Action::Quit.into(),
+            "r" => Action::Rotate(RotationDirection::Clockwise).into(),
+            "R" => Action::Rotate(RotationDirection::CounterClockwise).into(),
             "t" => {
                 state.render_infobar = !state.render_infobar;
                 Action::ReRender.into()


### PR DESCRIPTION
Closes #77 

Rotates an image with the r/R keys (clockwise, or counterclockwise)

Preserves the zoom level when rotating. (desired behavior?)

Small grammar fix in normal mode help.