### PR TITLE
Glob with progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +315,8 @@ name = "riv"
 version = "0.3.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -339,6 +359,11 @@ dependencies = [
 [[package]]
 name = "shellexpand"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "smallvec"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -449,6 +474,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
+"checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0ad6bf6a88548d1126045c413548df1453d9be094a8ab9fd59bf1fdd338da4f"
 "checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
@@ -482,6 +509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sdl2 0.32.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d051a07231e303f5f719da78cb6f7394f6d5b54f733aef5b0b447804a83edd7b"
 "checksum sdl2-sys 0.32.6 (registry+https://github.com/rust-lang/crates.io-index)" = "34e71125077d297d57e4c1acfe8981b5bdfbf5a20e7b589abfdcb33bf1127f86"
 "checksum shellexpand 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de7a5b5a9142fd278a10e0209b021a1b85849352e6951f4f914735c976737564"
+"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ natord = "1.0.9"
 shellexpand = "1.0"
 lazy_static = "1.3.0"
 regex = "1"
+crossbeam-channel = "0.3.8"
+crossbeam-utils = "0.6.5"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 trash = {git = "https://github.com/gurgalex/trash", tag = "0.1.0"}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,14 +12,14 @@ use std::path::PathBuf;
 pub struct Args {
     /// Parsed glob to scan for images over
     pub glob: glob::Paths,
-    /// dest_folder is the supplied or default folder for moving files
+    /// dest_folder is the supplied or default folder for moving files to
     pub dest_folder: PathBuf,
     /// provides the SortOrder specified by the user
     pub sort_order: SortOrder,
     /// whether or not to reverse sorting
     pub reverse: bool,
-    /// maximum length of files to display
-    pub max_length: usize,
+    /// maximum number of images to collect
+    pub max_length: Option<usize>,
     /// Start in fullscreen mode
     pub fullscreen: bool,
     /// New base directory defaults to std::env::current_dir
@@ -113,6 +113,11 @@ pub fn cli() -> Result<Args, String> {
     let reverse = matches.is_present("reverse");
 
     let max_length = value_t!(matches, "max-number-images", usize).unwrap_or(0);
+    // Case for 0 is unlimited images to match
+    let max_length = match max_length {
+        0 => None,
+        _ => Some(max_length),
+    };
     let fullscreen = matches.is_present("fullscreen");
 
     Ok(Args {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,8 +10,8 @@ use std::path::PathBuf;
 
 /// Args contains the arguments that have been successfully parsed by the clap cli app
 pub struct Args {
-    /// files is the vector of image file paths that match the supplied or default glob
-    pub files: Vec<PathBuf>,
+    /// Parsed glob to scan for images over
+    pub glob: glob::Paths,
     /// dest_folder is the supplied or default folder for moving files
     pub dest_folder: PathBuf,
     /// provides the SortOrder specified by the user
@@ -28,7 +28,6 @@ pub struct Args {
 
 /// cli sets up the command line app and parses the arguments, using clap.
 pub fn cli() -> Result<Args, String> {
-    let mut files = Vec::new();
     let matches = App::new("riv")
         .version("0.3.0")
         .about("The command line image viewer")
@@ -96,13 +95,7 @@ pub fn cli() -> Result<Args, String> {
     if let Ok(new_base_dir) = crate::new_base_dir(&path_glob) {
         base_dir = new_base_dir;
     }
-    let glob_matches = glob(&path_glob.to_string_lossy()).map_err(|e| e.to_string())?;
-    for path in glob_matches {
-        match path {
-            Ok(p) => push_image_path(&mut files, p),
-            Err(e) => eprintln!("Path not processable {}", e),
-        }
-    }
+    let glob = glob(&path_glob.to_string_lossy()).map_err(|e| e.to_string())?;
 
     let sort_order = match value_t!(matches, "sort-order", SortOrder) {
         Ok(order) => order,
@@ -123,7 +116,7 @@ pub fn cli() -> Result<Args, String> {
     let fullscreen = matches.is_present("fullscreen");
 
     Ok(Args {
-        files,
+        glob,
         dest_folder,
         sort_order,
         reverse,

--- a/src/infobar.rs
+++ b/src/infobar.rs
@@ -7,12 +7,12 @@ use crate::ui::{Mode, State};
 
 /// Text contains the strings required to print the infobar.
 pub struct Text {
-    /// Either displays the name of the current image or the current command the user is typing in
-    /// command mode
-    pub information: String,
     /// In normal mode this is the string represention of the index, in command mode this is
     /// "Command"
-    pub mode: String,
+    pub child_1: String,
+    /// Either displays the name of the current image or the current command the user is typing in
+    /// command mode
+    pub child_2: String,
 }
 
 impl Text {
@@ -53,6 +53,9 @@ impl Text {
             Mode::Success(msg) => ("Success".to_string(), msg.to_string()),
             Mode::Exit => ("Exit".to_string(), "Exiting... Goodbye".to_string()),
         };
-        Text { information, mode }
+        Text {
+            child_1: mode,
+            child_2: information,
+        }
     }
 }

--- a/src/infobar.rs
+++ b/src/infobar.rs
@@ -52,6 +52,7 @@ impl Text {
             Mode::Error(msg) => ("Error".to_string(), msg.to_string()),
             Mode::Success(msg) => ("Success".to_string(), msg.to_string()),
             Mode::Exit => ("Exit".to_string(), "Exiting... Goodbye".to_string()),
+            Mode::Loading => (" ".to_string(), " ".to_string()),
         };
         Text {
             child_1: mode,

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -27,19 +27,12 @@ pub fn incremental_glob(
     /*
     sketch of design
 
-    Set infobar text to indicate that glob (image) scanning has started
-    Every 0.5 seconds update the progress bar with count of scanned images so far.
-    However, in the event the image scan finished, update the progress bar
-    with the complete image count (progress or complete get there first perhaps)
+    Send a message saying that globbing has started.
+    Every 0.5 seconds send a progress update on how many images matched the glob.
+    A completion message with total images matched is sent when the glob is finished.
 
-    However, the completion message should update the UI immediately, regardless of how far
-    along the periodic progress indicator is.
-
-    The problem to solve is how to efficiently pause iteration every 0.5 seconds?
-
-    Would constantly sending the progress count to a bounded channel of capacity 1 be too slow?
-    The complete message would overwrite the progress message, so that'd be ideal.
-    It still doesn't solve immediate update on receipt of completion message.
+    The timer will exit when it tries to send another completion message, thus
+    all threads are cleaned up.
     */
 
     /// Internal messages for child thread communication

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -80,7 +80,6 @@ impl FromStr for Commands {
 /// Globs the passed path, returning an error if no images are in that path, glob::glob fails, or
 /// path is unexpected
 fn glob_path(screen: &mut Screen, path: &PathBuf) -> Result<Vec<PathBuf>, String> {
-
     let glob = glob::glob(&path.to_string_lossy()).map_err(|e| e.to_string())?;
     let (tx, rx) = bounded(5);
     let mut new_images = Vec::new();
@@ -98,9 +97,7 @@ fn glob_path(screen: &mut Screen, path: &PathBuf) -> Result<Vec<PathBuf>, String
                         child_1: " ".to_string(),
                         child_2: "Starting to scan images".to_string(),
                     };
-                    screen
-                        .render_infobar(text, text_color, &theme)
-                        .unwrap();
+                    screen.render_infobar(text, text_color, &theme).unwrap();
                     screen.canvas.present()
                 }
                 Ok(SendStatus::Progress(n)) => {
@@ -108,9 +105,7 @@ fn glob_path(screen: &mut Screen, path: &PathBuf) -> Result<Vec<PathBuf>, String
                         child_1: "In progress".to_string(),
                         child_2: format!("matched {} images", n),
                     };
-                    screen
-                        .render_infobar(text, text_color, &theme)
-                        .unwrap();
+                    screen.render_infobar(text, text_color, &theme).unwrap();
                     screen.canvas.present();
                 }
                 Ok(SendStatus::Complete(_)) => {
@@ -122,7 +117,7 @@ fn glob_path(screen: &mut Screen, path: &PathBuf) -> Result<Vec<PathBuf>, String
             }
         }
     })
-        .unwrap();
+    .unwrap();
     if new_images.is_empty() {
         let err_msg = format!("Path \"{}\" had no images", path.display());
         return Err(err_msg);
@@ -199,7 +194,6 @@ impl<'a> Program<'a> {
         };
         let msg = path_to_newglob.to_owned();
 
-
         let new_images = match glob_path(&mut self.screen, &path) {
             Ok(new_images) => new_images,
             Err(e) => {
@@ -207,9 +201,6 @@ impl<'a> Program<'a> {
                 return;
             }
         };
-
-        //let new_images = populate_images(&mut self.screen, glob);
-
 
         let target = match self.paths.current_image_path() {
             Some(path) => {
@@ -244,7 +235,6 @@ impl<'a> Program<'a> {
                 }
             }
         }
-
         self.ui_state.mode = Mode::Success(format!(
             "found {} images in {}",
             self.paths.images().len(),

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -108,6 +108,9 @@ fn glob_path(screen: &mut Screen, path: &PathBuf) -> Result<Vec<PathBuf>, String
                     screen.render_infobar(text, text_color, &theme).unwrap();
                     screen.canvas.present();
                 }
+                Ok(SendStatus::ReadError(e)) => {
+                    eprintln!("Path not processable: {}", e);
+                }
                 Ok(SendStatus::Complete(_)) => {
                     break;
                 }

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -307,7 +307,8 @@ impl<'a> Program<'a> {
             }
         };
         self.config.max_collect = new_actual_max;
-        self.paths.set_actual_maximum(new_actual_max.unwrap_or(std::usize::MAX));
+        self.paths
+            .set_actual_maximum(new_actual_max.unwrap_or(std::usize::MAX));
     }
 
     /// Enters command mode that gets user input and runs a set of possible commands based on user input.

--- a/src/program/command_mode.rs
+++ b/src/program/command_mode.rs
@@ -307,7 +307,7 @@ impl<'a> Program<'a> {
             }
         };
         self.config.max_collect = new_actual_max;
-        self.paths.set_actual_maximum(new_actual_max.unwrap_or(0));
+        self.paths.set_actual_maximum(new_actual_max.unwrap_or(std::usize::MAX));
     }
 
     /// Enters command mode that gets user input and runs a set of possible commands based on user input.

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -133,7 +133,7 @@ impl<'a> Program<'a> {
             Err(e) => panic!("Failed to load font {}", e),
         };
 
-        let mut screen = Screen {
+        let screen = Screen {
             sdl_context,
             canvas,
             texture_creator,
@@ -144,14 +144,12 @@ impl<'a> Program<'a> {
             dirty: false,
         };
 
-        // Prepare loading screen by setting background color
-        screen.canvas.set_draw_color(dark_grey());
-        screen.canvas.clear();
-        // Load first set of images
+        // Prepare loading images
+        // Start out initially with no images
         let images = Vec::new();
         let sorter = Sorter::new(sort_order, reverse);
-        //sorter.sort(&mut images);
 
+        // Prefill initial max viewable
         let paths = PathsBuilder::new(images, dest_folder, base_dir)
             .with_maximum_viewable(max_viewable)
             .build();
@@ -640,11 +638,15 @@ impl<'a> Program<'a> {
     fn run_loading_mode(&mut self) -> Result<(), String> {
         // Swallow events so that the window will show on first launch from cli
         for _ in self.screen.sdl_context.event_pump()?.poll_iter() {
+            // Load and sort the images
             let glob = std::mem::replace(&mut self.ui_state.register.loading_glob, None);
             let mut images = populate_images(&mut self.screen, glob.unwrap());
             self.sorter.sort(images.as_mut_slice());
             self.paths.reload_images(images);
+            // We are only in loading mode to load images, not process
+            // any events.
             self.ui_state.mode = Mode::Normal;
+            break;
         }
         Ok(())
     }

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -45,7 +45,7 @@ pub struct Program<'a> {
 }
 
 /// Populate images from glob with progress
-fn populate_images(screen: &mut Screen, glob: glob::Paths) -> Vec<PathBuf> {
+pub fn populate_images(screen: &mut Screen, glob: glob::Paths) -> Vec<PathBuf> {
     let (tx, rx) = bounded(5);
     let mut images = Vec::new();
 
@@ -92,8 +92,7 @@ fn populate_images(screen: &mut Screen, glob: glob::Paths) -> Vec<PathBuf> {
         }
     })
     .unwrap();
-    // Discard images that had errors globbing
-    images.into_iter().map(Result::unwrap).collect()
+    images
 }
 
 impl<'a> Program<'a> {

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -130,10 +130,7 @@ impl<'a> Program<'a> {
         let dest_folder = args.dest_folder;
         let reverse = args.reverse;
         let sort_order = args.sort_order;
-        let max_length = args.max_length;
         let base_dir = args.base_dir;
-
-        let max_viewable = max_length;
 
         let font_bytes = include_bytes!("../../resources/Roboto-Medium.ttf");
         let font_bytes = match RWops::from_bytes(font_bytes) {
@@ -171,9 +168,7 @@ impl<'a> Program<'a> {
         let sorter = Sorter::new(sort_order, reverse);
 
         // Prefill initial max viewable
-        let paths = PathsBuilder::new(images, dest_folder, base_dir)
-            .with_maximum_viewable(max_viewable.unwrap_or(0))
-            .build();
+        let paths = PathsBuilder::new(images, dest_folder, base_dir).build();
         let mut config = Config::new();
         config.max_collect = args.max_length;
         let mut program = Program {

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -73,6 +73,9 @@ pub fn populate_images(screen: &mut Screen, glob: glob::Paths) -> Vec<PathBuf> {
                     screen.render_infobar(text, text_color, &theme).unwrap();
                     screen.canvas.present();
                 }
+                Ok(SendStatus::ReadError(e)) => {
+                    eprintln!("Path not processable: {}", e);
+                }
                 Ok(SendStatus::Complete(n)) => {
                     let theme = mode_colors(&Mode::Success("".to_string()));
                     let text_color = mode_text_color(&Mode::Success("".to_string()));

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -161,6 +161,7 @@ impl<'a> Program<'a> {
             paths,
             ui_state: ui::State {
                 fullscreen: args.fullscreen,
+                mode: Mode::Loading,
                 ..Default::default()
             },
             sorter,
@@ -642,6 +643,10 @@ impl<'a> Program<'a> {
         'main_loop: loop {
             let mode = &self.ui_state.mode.clone();
             match mode {
+                Mode::Loading => {
+                    self.render_screen(false)?;
+                    self.ui_state.mode = Mode::Normal;
+                }
                 Mode::Normal => {
                     self.run_normal_mode()?;
                     // Don't reset image zoom and offset when changing modes

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -144,7 +144,10 @@ impl<'a> Program<'a> {
             dirty: false,
         };
 
-        // Prepare loading screen
+        // Prepare loading screen by setting background color
+        screen.canvas.set_draw_color(dark_grey());
+        screen.canvas.clear();
+        // Load first set of images
         let mut images = populate_images(&mut screen, args.glob);
 
         let sorter = Sorter::new(sort_order, reverse);

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -640,17 +640,15 @@ impl<'a> Program<'a> {
 
     fn run_loading_mode(&mut self) -> Result<(), String> {
         // Swallow events so that the window will show on first launch from cli
-        for _ in self.screen.sdl_context.event_pump()?.poll_iter() {
-            // Load and sort the images
-            let glob = std::mem::replace(&mut self.ui_state.register.loading_glob, None);
-            let mut images = populate_images(&mut self.screen, glob.unwrap());
-            self.sorter.sort(images.as_mut_slice());
-            self.paths.reload_images(images);
-            // We are only in loading mode to load images, not process
-            // any events.
-            self.ui_state.mode = Mode::Normal;
-            break;
-        }
+        let _first_event = self.screen.sdl_context.event_pump()?.poll_iter().next();
+        // Load and sort the images
+        let glob = std::mem::replace(&mut self.ui_state.register.loading_glob, None);
+        let mut images = populate_images(&mut self.screen, glob.unwrap());
+        self.sorter.sort(images.as_mut_slice());
+        self.paths.reload_images(images);
+        // We are only in loading mode to load images, not process
+        // any events.
+        self.ui_state.mode = Mode::Normal;
         Ok(())
     }
 

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -683,12 +683,10 @@ impl<'a> Program<'a> {
     /// Central run function that starts by default in Normal mode
     /// Switches modes allowing events to be interpreted in different ways
     pub fn run(&mut self) -> Result<(), String> {
-        self.render_screen(false)?;
         'main_loop: loop {
             let mode = &self.ui_state.mode.clone();
             match mode {
                 Mode::Loading => {
-                    self.render_screen(false)?;
                     self.run_loading_mode()?;
                 }
                 Mode::Normal => {

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -167,7 +167,7 @@ impl<'a> Program<'a> {
         let _ = screen.sdl_context.event_pump()?.poll_iter().next();
         // Delay on Mac OS to give the window a chance to show?
         #[cfg(target_os = "macos")]
-            std::thread::sleep(std::time::Duration::from_millis(100));
+        std::thread::sleep(std::time::Duration::from_millis(100));
         // Start out initially with no images
 
         let images = Vec::new();
@@ -661,7 +661,6 @@ impl<'a> Program<'a> {
     }
 
     fn run_loading_mode(&mut self) -> Result<(), String> {
-
         // Allow never loop for mac os window showing
         #[allow(clippy::never_loop)]
         for _ in self.screen.sdl_context.event_pump()?.poll_iter() {

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -239,7 +239,7 @@ pub fn mode_colors(m: &Mode) -> Colors {
             bg_rect_2: green(),
             bg_rest: grey(),
         },
-        Mode::Command(_) => Colors {
+        Mode::Command(_) | Mode::Loading => Colors {
             bg_rect_left: light_yellow(),
             bg_rect_2: yellow(),
             bg_rest: grey(),
@@ -255,9 +255,12 @@ pub fn mode_colors(m: &Mode) -> Colors {
 /// Text color theme
 pub fn mode_text_color(m: &Mode) -> Color {
     match m {
-        Mode::Normal | Mode::MultiNormal | Mode::Exit | Mode::Command(_) | Mode::Success(_) => {
-            dark_text_color()
-        }
+        Mode::Loading
+        | Mode::Normal
+        | Mode::MultiNormal
+        | Mode::Exit
+        | Mode::Command(_)
+        | Mode::Success(_) => dark_text_color(),
         Mode::Error(_) => light_text_color(),
     }
 }

--- a/src/program/render.rs
+++ b/src/program/render.rs
@@ -1,4 +1,3 @@
-use crate::infobar;
 use crate::program::{make_dst, Program};
 use crate::ui::{HelpRender, Mode, RotAngle};
 use sdl2::image::LoadTexture;
@@ -6,15 +5,23 @@ use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use sdl2::render::BlendMode;
 
-const PADDING: i32 = 30;
-const HALF_PAD: i32 = 15;
-const LINE_HEIGHT: i32 = 22;
-const LINE_PADDING: i32 = 5;
+/// Padding away from left of screen
+pub const PADDING: i32 = 30;
+/// Half distance padding from left of screen
+pub const HALF_PAD: i32 = PADDING / 2;
+/// Height of line for infobar
+pub const LINE_HEIGHT: i32 = 22;
+/// Padding inward text of infobar
+pub const LINE_PADDING: i32 = 5;
 
-struct Colors {
-    primary: Color,
-    secondary: Color,
-    tertiary: Color,
+/// Colors to use for infobar style
+pub struct Colors {
+    /// Background color of Left-most (1st) rect of infobar.
+    pub bg_rect_left: Color,
+    /// Background color of 2nd rect of infobar
+    pub bg_rect_2: Color,
+    /// Background color of infobar with no covering rectangles
+    pub bg_rest: Color,
 }
 
 impl<'a> Program<'a> {
@@ -28,7 +35,11 @@ impl<'a> Program<'a> {
         self.screen.canvas.clear();
         self.render_image(force_render)?;
         if self.ui_state.render_infobar {
-            self.render_infobar()?;
+            let text =
+                crate::infobar::Text::update(&self.ui_state.mode, &self.paths, &self.ui_state);
+            let theme = mode_colors(&self.ui_state.mode);
+            let text_color = mode_text_color(&self.ui_state.mode);
+            self.screen.render_infobar(text, text_color, &theme)?;
         }
         self.render_help()?;
 
@@ -126,72 +137,6 @@ impl<'a> Program<'a> {
         src_dims.x > dest_dims.x || src_dims.y > dest_dims.y
     }
 
-    fn render_infobar(&mut self) -> Result<(), String> {
-        let text_color = mode_text_color(&self.ui_state.mode);
-        let text = infobar::Text::update(&self.ui_state.mode, &self.paths, &self.ui_state);
-        // Load the filename texture
-        let filename_surface = self
-            .screen
-            .font
-            .render(&text.information)
-            .blended(text_color)
-            .map_err(|e| e.to_string())?;
-        let filename_texture = self
-            .screen
-            .texture_creator
-            .create_texture_from_surface(&filename_surface)
-            .map_err(|e| e.to_string())?;
-        let filename_dimensions = filename_texture.query();
-        // Load the index texture
-        let index_surface = self
-            .screen
-            .font
-            .render(&text.mode)
-            .blended(text_color)
-            .map_err(|e| e.to_string())?;
-        let index_texture = self
-            .screen
-            .texture_creator
-            .create_texture_from_surface(&index_surface)
-            .map_err(|e| e.to_string())?;
-        let index_dimensions = index_texture.query();
-        // Draw the Bar
-        let dims = (
-            index_dimensions.height,
-            index_dimensions.width,
-            filename_dimensions.width,
-        );
-        self.render_bar(dims)?;
-        // Copy the text textures
-        let y = (self.screen.canvas.viewport().height() - index_dimensions.height) as i32;
-        if let Err(e) = self.screen.canvas.copy(
-            &index_texture,
-            None,
-            Rect::new(
-                PADDING as i32,
-                y,
-                index_dimensions.width,
-                index_dimensions.height,
-            ),
-        ) {
-            eprintln!("Failed to copy text to screen {}", e);
-        }
-        if let Err(e) = self.screen.canvas.copy(
-            &filename_texture,
-            None,
-            Rect::new(
-                (index_dimensions.width + PADDING as u32 * 2) as i32,
-                y,
-                filename_dimensions.width,
-                filename_dimensions.height,
-            ),
-        ) {
-            eprintln!("Failed to copy text to screen {}", e);
-            return Ok(());
-        }
-        Ok(())
-    }
-
     fn render_help(&mut self) -> Result<(), String> {
         let text = match self.ui_state.render_help {
             HelpRender::None => return Ok(()),
@@ -248,32 +193,6 @@ impl<'a> Program<'a> {
         Ok(())
     }
 
-    fn render_bar(&mut self, dims: (u32, u32, u32)) -> Result<(), String> {
-        let colors = mode_colors(&self.ui_state.mode);
-        let height = dims.0;
-        let width = self.screen.canvas.viewport().width();
-        let y = (self.screen.canvas.viewport().height() - height) as i32;
-        let mut x = 0;
-        let mut w = dims.1 + HALF_PAD as u32 * 3;
-        self.screen.canvas.set_draw_color(colors.primary);
-        if let Err(e) = self.screen.canvas.fill_rect(Rect::new(x, y, w, height)) {
-            eprintln!("Failed to draw bar {}", e);
-        }
-        x += w as i32;
-        w = dims.2 + PADDING as u32 * 2;
-        self.screen.canvas.set_draw_color(colors.secondary);
-        if let Err(e) = self.screen.canvas.fill_rect(Rect::new(x, y, w, height)) {
-            eprintln!("Failed to draw bar {}", e);
-        }
-        x += w as i32;
-        w = width;
-        self.screen.canvas.set_draw_color(colors.tertiary);
-        if let Err(e) = self.screen.canvas.fill_rect(Rect::new(x, y, w, height)) {
-            eprintln!("Failed to draw bar {}", e);
-        }
-        Ok(())
-    }
-
     fn render_help_box(&mut self, dims: (u32, u32)) -> Result<(), String> {
         let height = dims.0;
         let y = (self.screen.canvas.viewport().height() as f32 / 2.0 - height as f32 / 2.0) as i32;
@@ -290,7 +209,11 @@ impl<'a> Program<'a> {
     fn render_blank(&mut self) -> Result<(), String> {
         self.screen.canvas.clear();
         if self.ui_state.render_infobar {
-            self.render_infobar()?;
+            let text =
+                crate::infobar::Text::update(&self.ui_state.mode, &self.paths, &self.ui_state);
+            let theme = mode_colors(&self.ui_state.mode);
+            let text_color = mode_text_color(&self.ui_state.mode);
+            self.screen.render_infobar(text, text_color, &theme)?;
         }
         self.render_help()?;
         self.screen.canvas.present();
@@ -298,37 +221,39 @@ impl<'a> Program<'a> {
     }
 }
 
-fn mode_colors(m: &Mode) -> Colors {
+/// Colors themes for infobar
+pub fn mode_colors(m: &Mode) -> Colors {
     match m {
         Mode::Normal | Mode::MultiNormal => Colors {
-            primary: light_blue(),
-            secondary: blue(),
-            tertiary: grey(),
+            bg_rect_left: light_blue(),
+            bg_rect_2: blue(),
+            bg_rest: grey(),
         },
         Mode::Error(_) => Colors {
-            primary: light_red(),
-            secondary: red(),
-            tertiary: grey(),
+            bg_rect_left: light_red(),
+            bg_rect_2: red(),
+            bg_rest: grey(),
         },
         Mode::Success(_) => Colors {
-            primary: light_green(),
-            secondary: green(),
-            tertiary: grey(),
+            bg_rect_left: light_green(),
+            bg_rect_2: green(),
+            bg_rest: grey(),
         },
         Mode::Command(_) => Colors {
-            primary: light_yellow(),
-            secondary: yellow(),
-            tertiary: grey(),
+            bg_rect_left: light_yellow(),
+            bg_rect_2: yellow(),
+            bg_rest: grey(),
         },
         Mode::Exit => Colors {
-            primary: light_blue(),
-            secondary: blue(),
-            tertiary: grey(),
+            bg_rect_left: light_blue(),
+            bg_rect_2: blue(),
+            bg_rest: grey(),
         },
     }
 }
 
-fn mode_text_color(m: &Mode) -> Color {
+/// Text color theme
+pub fn mode_text_color(m: &Mode) -> Color {
     match m {
         Mode::Normal | Mode::MultiNormal | Mode::Exit | Mode::Command(_) | Mode::Success(_) => {
             dark_text_color()
@@ -337,15 +262,17 @@ fn mode_text_color(m: &Mode) -> Color {
     }
 }
 
-fn dark_grey() -> Color {
+/// RGB for dark grey
+pub fn dark_grey() -> Color {
     Color::RGB(45, 45, 45)
 }
-
-fn dark_text_color() -> Color {
+/// Dark text color
+pub fn dark_text_color() -> Color {
     Color::RGBA(52, 56, 56, 255)
 }
 
-fn light_text_color() -> Color {
+/// Light text color
+pub fn light_text_color() -> Color {
     Color::RGBA(255, 255, 255, 255)
 }
 
@@ -353,39 +280,48 @@ fn help_background_color() -> Color {
     Color::RGBA(0, 223, 252, 200)
 }
 
-fn light_blue() -> Color {
+/// RGB for light blue
+pub fn light_blue() -> Color {
     Color::RGB(0, 223, 252)
 }
 
-fn blue() -> Color {
+/// RGB for blue
+pub fn blue() -> Color {
     Color::RGB(0, 180, 204)
 }
 
-fn light_red() -> Color {
+/// RGB for light red
+pub fn light_red() -> Color {
     Color::RGB(252, 45, 45)
 }
 
-fn red() -> Color {
+/// RGB for red
+pub fn red() -> Color {
     Color::RGB(223, 0, 0)
 }
 
-fn light_green() -> Color {
+/// RGB for light green
+pub fn light_green() -> Color {
     Color::RGB(45, 252, 45)
 }
 
-fn green() -> Color {
+/// RGB for green
+pub fn green() -> Color {
     Color::RGB(0, 223, 0)
 }
 
-fn light_yellow() -> Color {
+/// RGB for light yellow
+pub fn light_yellow() -> Color {
     Color::RGB(255, 255, 170)
 }
 
-fn yellow() -> Color {
+/// RGB for yellow
+pub fn yellow() -> Color {
     Color::RGB(255, 255, 130)
 }
 
-fn grey() -> Color {
+/// RGB for grey
+pub fn grey() -> Color {
     Color::RGB(52, 56, 56)
 }
 

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,5 +1,9 @@
 //! Screen contains the Screen struct which contains all SDL initialised data required
 //! for building the window and rendering to screen.
+use crate::infobar::Text;
+use crate::program::{Colors, HALF_PAD, PADDING};
+use sdl2::pixels::Color;
+use sdl2::rect::Rect;
 use sdl2::render::{TextureCreator, WindowCanvas};
 use sdl2::ttf::Font;
 use sdl2::video::{FullscreenType, WindowContext};
@@ -27,6 +31,99 @@ pub struct Screen<'a> {
 }
 
 impl Screen<'_> {
+    /// Renders infobar on screen
+    pub fn render_infobar(
+        &mut self,
+        text: Text,
+        text_color: Color,
+        theme: &Colors,
+    ) -> Result<(), String> {
+        let text = text; //infobar::Text::update(&self.ui_state.mode, &self.paths, &self.ui_state);
+                         // Load the filename texture
+        let filename_surface = self
+            .font
+            .render(&text.child_2)
+            .blended(text_color)
+            .map_err(|e| e.to_string())?;
+        let filename_texture = self
+            .texture_creator
+            .create_texture_from_surface(&filename_surface)
+            .map_err(|e| e.to_string())?;
+        let filename_dimensions = filename_texture.query();
+        // Load the index texture
+        let index_surface = self
+            .font
+            .render(&text.child_1)
+            .blended(text_color)
+            .map_err(|e| e.to_string())?;
+        let index_texture = self
+            .texture_creator
+            .create_texture_from_surface(&index_surface)
+            .map_err(|e| e.to_string())?;
+        let index_dimensions = index_texture.query();
+        // Draw the Bar
+        let dims = (
+            index_dimensions.height,
+            index_dimensions.width,
+            filename_dimensions.width,
+        );
+        self.render_bar(dims, theme)?;
+        // Copy the text textures
+        let y = (self.canvas.viewport().height() - index_dimensions.height) as i32;
+        if let Err(e) = self.canvas.copy(
+            &index_texture,
+            None,
+            Rect::new(
+                PADDING as i32,
+                y,
+                index_dimensions.width,
+                index_dimensions.height,
+            ),
+        ) {
+            eprintln!("Failed to copy text to screen {}", e);
+        }
+        if let Err(e) = self.canvas.copy(
+            &filename_texture,
+            None,
+            Rect::new(
+                (index_dimensions.width + PADDING as u32 * 2) as i32,
+                y,
+                filename_dimensions.width,
+                filename_dimensions.height,
+            ),
+        ) {
+            eprintln!("Failed to copy text to screen {}", e);
+            return Ok(());
+        }
+        Ok(())
+    }
+
+    fn render_bar(&mut self, dims: (u32, u32, u32), theme: &Colors) -> Result<(), String> {
+        let colors = theme;
+        let height = dims.0;
+        let width = self.canvas.viewport().width();
+        let y = (self.canvas.viewport().height() - height) as i32;
+        let mut x = 0;
+        let mut w = dims.1 + HALF_PAD as u32 * 3;
+        self.canvas.set_draw_color(colors.bg_rect_left);
+        if let Err(e) = self.canvas.fill_rect(Rect::new(x, y, w, height)) {
+            eprintln!("Failed to draw bar {}", e);
+        }
+        x += w as i32;
+        w = dims.2 + PADDING as u32 * 2;
+        self.canvas.set_draw_color(colors.bg_rect_2);
+        if let Err(e) = self.canvas.fill_rect(Rect::new(x, y, w, height)) {
+            eprintln!("Failed to draw bar {}", e);
+        }
+        x += w as i32;
+        w = width;
+        self.canvas.set_draw_color(colors.bg_rest);
+        if let Err(e) = self.canvas.fill_rect(Rect::new(x, y, w, height)) {
+            eprintln!("Failed to draw bar {}", e);
+        }
+        Ok(())
+    }
+
     /// Updates window for fullscreen state
     pub fn update_fullscreen(&mut self, fullscreen: bool) -> Result<(), String> {
         let fullscreen_type = if fullscreen { Off } else { True };

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -193,6 +193,8 @@ pub enum Mode {
     Error(String),
     /// Mode that is used to display success messages
     Success(String),
+    /// Loading screen
+    Loading,
     /// Terminate condition, if this mode is set the program will stop execution
     Exit,
 }
@@ -212,12 +214,15 @@ pub enum HelpRender {
 pub struct Register<'a> {
     /// Current action to perform later
     pub cur_action: ProcessAction<'a>,
+    /// Glob iterator for loading screen
+    pub loading_glob: Option<glob::Paths>,
 }
 
 impl<'a> Default for Register<'a> {
     fn default() -> Self {
         Self {
             cur_action: ProcessAction::new(Action::Noop, 1),
+            loading_glob: None,
         }
     }
 }


### PR DESCRIPTION
This PR aims to resolve #89 

Getting progress indications from a long-running glob isn't the most mentally taxing part. Showing the progress at first launch is where the need to restructure has reached a tipping point. Restructuring a code base is the major mental effort.

The major roadblock I've encountered is the need to have all images loaded before the `Program` struct can be fully constructed.

This is a problem, since to indicate progress, I need to render to the screen. However, all the screen rendering methods (specifically relating to the infobar) are on `Program`.

# workarounds or solutions

The following remedies may overlap to fix this problem.

1. Start out with no images (empty vec), and switch to a loading screen Mode. Then switch to Normal mode once first batch of images is loaded.

2. Move some of the rendering methods to the `screen` struct.
* Specialize some of the infobars to take ui_state as and argument, and others not (like loading mode)