### PR TITLE
Expanded the supported image formats to match SDL2

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,8 +137,12 @@ pub(crate) fn push_image_path(v: &mut Vec<PathBuf>, p: PathBuf) {
     if let Some(ext) = p.extension() {
         if let Some(ext_str) = ext.to_str() {
             let low = ext_str.to_string().to_lowercase();
-            if low == "jpg" || low == "jpeg" || low == "png" || low == "bmp" || low == "webp" {
-                v.push(p)
+            match low.as_ref() {
+                "jpg" | "jpeg" | "png" | "bmp" | "webp" | "gif" | "lbm" | "pcx" | "pnm" | "svg"
+                | "tga" | "tiff" | "xcf" | "xpm" | "xv" => v.push(p),
+                _ => {
+                    println!("{} is not a supported image format", low);
+                }
             }
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -141,7 +141,7 @@ pub(crate) fn push_image_path(v: &mut Vec<PathBuf>, p: PathBuf) {
                 "jpg" | "jpeg" | "png" | "bmp" | "webp" | "gif" | "lbm" | "pcx" | "pnm" | "svg"
                 | "tga" | "tiff" | "xcf" | "xpm" | "xv" => v.push(p),
                 _ => {
-                    println!("{} is not a supported image format", low);
+                    eprintln!("{} is not a supported image format", low);
                 }
             }
         }


### PR DESCRIPTION
SDL2 supports a lot more image formats than what was accepted by this program.

Fixes #96

Attached is some images with various formats that you can test with. Unfortunately, GIMP does not support some file formats so I don't have them.

[yuri_tsukikage.zip](https://github.com/Davejkane/riv/files/3796289/yuri_tsukikage.zip)